### PR TITLE
Duplicate-volume detection + dashboard test/ephemeral filters

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -22,6 +22,9 @@
   // --- Carousel ---
   buildCarousel(data.repos);
 
+  // --- Duplicate-volumes panel ---
+  renderDuplicates(data.duplicateVolumes || []);
+
   // --- Activity chart ---
   const activityChart = echarts.init(document.getElementById('activity-chart'));
   activityChart.setOption({
@@ -127,6 +130,48 @@
     activityChart.resize();
     taxonomyChart.resize();
   });
+
+
+  // --- Duplicate-volumes panel ---
+
+  function renderDuplicates(groups) {
+    const section = document.getElementById('dup-section');
+    if (!groups.length) { section.style.display = 'none'; return; }
+    section.style.display = '';
+    document.getElementById('dup-count').textContent = groups.length;
+
+    // Category -> {label, colour}; ordered by curation priority in the data already.
+    const CATS = {
+      'org-org':     { label: 'Org ↔ Org',      color: '#b31d28' },
+      'promotion':   { label: 'Personal → Org', color: '#b35900' },
+      'cross-owner': { label: 'Cross-owner',          color: '#9a6700' },
+      'same-owner':  { label: 'Same owner',           color: '#6a737d' },
+    };
+    const tbody = document.getElementById('dup-tbody');
+
+    groups.forEach(g => {
+      const cat = CATS[g.category] || { label: g.category, color: '#6a737d' };
+      const repos = (g.repos || []).map(r =>
+        `<a href="https://github.com/${escapeHTML(r.nameWithOwner)}" target="_blank">` +
+        `${escapeHTML(r.nameWithOwner)}</a>` +
+        (r.isOrg ? ' <span class="org-tag">org</span>' : '')
+      ).join('<br>');
+      const species = [...new Set((g.repos || [])
+        .map(r => r.species).filter(s => s && s !== 'Unknown'))].join(', ') || '—';
+      const sha = String(g.checksum || '');
+
+      const tr = document.createElement('tr');
+      tr.className = 'repo-row';
+      tr.style.cursor = 'default';
+      tr.innerHTML = `
+        <td><span class="dup-badge" style="background:${cat.color}">${cat.label}</span></td>
+        <td>${repos}</td>
+        <td>${escapeHTML(species)}</td>
+        <td><code class="dup-sha" title="${escapeHTML(sha)}">${escapeHTML(sha.slice(0, 12))}…</code></td>
+      `;
+      tbody.appendChild(tr);
+    });
+  }
 
 
   // --- Carousel ---

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -12,119 +12,145 @@
     return;
   }
 
-  // --- Summary bar ---
-  document.getElementById('total-repos').textContent  = data.totalRepos;
-  document.getElementById('total-issues').textContent = data.totalOpenIssues;
-  document.getElementById('total-prs').textContent    = data.totalOpenPRs;
   document.getElementById('generated-at').textContent =
     new Date(data.generatedAt).toLocaleString();
 
-  // --- Carousel ---
+  // --- Carousel (all repos; screenshot-bearing only) ---
   buildCarousel(data.repos);
 
-  // --- Duplicate-volumes panel ---
-  renderDuplicates(data.duplicateVolumes || []);
-
-  // --- Activity chart ---
+  // --- Charts (initialised once; fed the filtered repo set by renderAll) ---
   const activityChart = echarts.init(document.getElementById('activity-chart'));
-  activityChart.setOption({
-    title: { text: 'Repository Activity', left: 'center', textStyle: { fontSize: 13 } },
-    tooltip: { trigger: 'axis' },
-    xAxis: {
-      type: 'category',
-      data: ['Last Day', 'Last Week', 'Last Month', 'Last Year'],
-    },
-    yAxis: { type: 'value', name: 'Repos', minInterval: 1 },
-    series: [{
-      type: 'bar',
-      data: [
-        data.activity.last_day,
-        data.activity.last_week,
-        data.activity.last_month,
-        data.activity.last_year,
-      ],
-      itemStyle: { color: '#1a3a52' },
-    }],
-    grid: { left: 50, right: 20, bottom: 40, top: 50 },
-  });
-
-  // --- Taxonomy pie chart ---
   const taxonomyChart = echarts.init(document.getElementById('taxonomy-chart'));
   const taxSelect = document.getElementById('tax-level');
 
-  function updateTaxonomy() {
+  // --- Filters: "Hide test repositories" / "Include ephemeral repositories" ---
+  const hideTestCb = document.getElementById('hide-test');
+  const includeEphemeralCb = document.getElementById('include-ephemeral');
+  const filterCountEl = document.getElementById('filter-count');
+  const DUP_CATEGORY_PRIORITY = { 'org-org': 0, 'promotion': 1, 'cross-owner': 2, 'same-owner': 3 };
+
+  hideTestCb.addEventListener('change', renderAll);
+  includeEphemeralCb.addEventListener('change', renderAll);
+  taxSelect.addEventListener('change', () => renderTaxonomy(data.repos.filter(repoVisible)));
+  renderAll();
+
+  function repoVisible(r) {
+    if (hideTestCb.checked && r.isTest) return false;          // hide reload-and-test repos
+    if (!includeEphemeralCb.checked && r.isEphemeral) return false;  // optionally hide ephemeral
+    return true;
+  }
+
+  function renderAll() {
+    const repos = data.repos.filter(repoVisible);
+    document.getElementById('total-repos').textContent  = repos.length;
+    document.getElementById('total-issues').textContent = repos.reduce((s, r) => s + (r.openIssues || 0), 0);
+    document.getElementById('total-prs').textContent    = repos.reduce((s, r) => s + (r.openPRs || 0), 0);
+    filterCountEl.textContent = repos.length === data.repos.length
+      ? `${data.repos.length} repositories`
+      : `showing ${repos.length} of ${data.repos.length} repositories`;
+    renderActivity(repos);
+    renderTaxonomy(repos);
+    renderDuplicates(filteredDuplicateGroups());
+    renderRepoTable(repos);
+  }
+
+  function renderActivity(repos) {
+    const now = Date.now();
+    const w = { day: 0, week: 0, month: 0, year: 0 };
+    for (const r of repos) {
+      if (!r.pushedAt) continue;
+      const days = (now - new Date(r.pushedAt).getTime()) / 86400000;
+      if (days <= 1) w.day++;
+      if (days <= 7) w.week++;
+      if (days <= 30) w.month++;
+      if (days <= 365) w.year++;
+    }
+    activityChart.setOption({
+      title: { text: 'Repository Activity', left: 'center', textStyle: { fontSize: 13 } },
+      tooltip: { trigger: 'axis' },
+      xAxis: { type: 'category', data: ['Last Day', 'Last Week', 'Last Month', 'Last Year'] },
+      yAxis: { type: 'value', name: 'Repos', minInterval: 1 },
+      series: [{ type: 'bar', data: [w.day, w.week, w.month, w.year], itemStyle: { color: '#1a3a52' } }],
+      grid: { left: 50, right: 20, bottom: 40, top: 50 },
+    });
+  }
+
+  function renderTaxonomy(repos) {
     const level = taxSelect.value;
-    const counts = data.taxonomy[level] || {};
+    const counts = {};
+    for (const r of repos) {
+      const raw = r.accession ? r.accession[level] : undefined;
+      const val = (Array.isArray(raw) ? raw[1] : raw) || 'Unknown';
+      counts[val] = (counts[val] || 0) + 1;
+    }
     const chartData = Object.entries(counts)
       .sort((a, b) => b[1] - a[1])
       .map(([name, value]) => ({ name, value }));
-
     taxonomyChart.setOption({
-      title: {
-        text: `By ${level.charAt(0).toUpperCase() + level.slice(1)}`,
-        left: 'center',
-        textStyle: { fontSize: 13 },
-      },
-      tooltip: {
-        trigger: 'item',
-        formatter: '{b}: {c} ({d}%)',
-      },
-      series: [{
-        type: 'pie',
-        radius: ['30%', '65%'],
-        data: chartData,
-        label: { fontSize: 11 },
-      }],
+      title: { text: `By ${level.charAt(0).toUpperCase() + level.slice(1)}`, left: 'center', textStyle: { fontSize: 13 } },
+      tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+      series: [{ type: 'pie', radius: ['30%', '65%'], data: chartData, label: { fontSize: 11 } }],
     }, true);
   }
 
-  taxSelect.addEventListener('change', updateTaxonomy);
-  updateTaxonomy();
-
-  // --- Repo table ---
-  const tbody = document.getElementById('repo-tbody');
-
-  data.repos.forEach(repo => {
-    const pushedDate = repo.pushedAt
-      ? new Date(repo.pushedAt).toLocaleDateString()
-      : '—';
-
-    // Main row
-    const tr = document.createElement('tr');
-    tr.className = 'repo-row';
-    tr.innerHTML = `
-      <td>
-        <span class="expand-indicator">▶</span>
-        <a href="https://github.com/${repo.nameWithOwner}" target="_blank"
-           onclick="event.stopPropagation()">${repo.nameWithOwner}</a>
-      </td>
-      <td>${pushedDate}</td>
-      <td>${repo.openIssues}</td>
-      <td>${repo.openPRs}</td>
-      <td>${repo.screenshotCount}</td>
-    `;
-
-    // Detail row (hidden by default)
-    const detailTr = document.createElement('tr');
-    detailTr.className = 'detail-row';
-    detailTr.style.display = 'none';
-
-    const detailTd = document.createElement('td');
-    detailTd.colSpan = 5;
-    detailTd.innerHTML = buildDetailHTML(repo);
-    detailTr.appendChild(detailTd);
-
-    // Toggle on row click
-    const indicator = tr.querySelector('.expand-indicator');
-    tr.addEventListener('click', () => {
-      const open = detailTr.style.display !== 'none';
-      detailTr.style.display = open ? 'none' : 'table-row';
-      indicator.textContent = open ? '▶' : '▼';
+  function renderRepoTable(repos) {
+    const tbody = document.getElementById('repo-tbody');
+    tbody.innerHTML = '';
+    repos.forEach(repo => {
+      const pushedDate = repo.pushedAt ? new Date(repo.pushedAt).toLocaleDateString() : '—';
+      const tr = document.createElement('tr');
+      tr.className = 'repo-row';
+      tr.innerHTML = `
+        <td>
+          <span class="expand-indicator">▶</span>
+          <a href="https://github.com/${repo.nameWithOwner}" target="_blank"
+             onclick="event.stopPropagation()">${repo.nameWithOwner}</a>
+        </td>
+        <td>${pushedDate}</td>
+        <td>${repo.openIssues}</td>
+        <td>${repo.openPRs}</td>
+        <td>${repo.screenshotCount}</td>
+      `;
+      const detailTr = document.createElement('tr');
+      detailTr.className = 'detail-row';
+      detailTr.style.display = 'none';
+      const detailTd = document.createElement('td');
+      detailTd.colSpan = 5;
+      detailTd.innerHTML = buildDetailHTML(repo);
+      detailTr.appendChild(detailTd);
+      const indicator = tr.querySelector('.expand-indicator');
+      tr.addEventListener('click', () => {
+        const open = detailTr.style.display !== 'none';
+        detailTr.style.display = open ? 'none' : 'table-row';
+        indicator.textContent = open ? '▶' : '▼';
+      });
+      tbody.appendChild(tr);
+      tbody.appendChild(detailTr);
     });
+  }
 
-    tbody.appendChild(tr);
-    tbody.appendChild(detailTr);
-  });
+  function categorizeDuplicate(repos) {
+    const org = repos.filter(r => r.isOrg);
+    const personal = repos.filter(r => !r.isOrg);
+    if (org.length && personal.length) return 'promotion';
+    if (org.length > 1) return 'org-org';
+    if (new Set(repos.map(r => r.nameWithOwner.split('/')[0])).size === 1) return 'same-owner';
+    return 'cross-owner';
+  }
+
+  // Re-derive duplicate groups for the active filter: drop hidden repos, drop groups that
+  // fall below 2 visible repos, then re-categorize and re-sort from what remains.
+  function filteredDuplicateGroups() {
+    const out = [];
+    for (const g of (data.duplicateVolumes || [])) {
+      const reps = (g.repos || []).filter(repoVisible);
+      if (reps.length < 2) continue;
+      out.push({ checksum: g.checksum, category: categorizeDuplicate(reps), repos: reps });
+    }
+    out.sort((a, b) => (DUP_CATEGORY_PRIORITY[a.category] ?? 9) - (DUP_CATEGORY_PRIORITY[b.category] ?? 9)
+                       || a.checksum.localeCompare(b.checksum));
+    return out;
+  }
 
   window.addEventListener('resize', () => {
     activityChart.resize();
@@ -136,18 +162,19 @@
 
   function renderDuplicates(groups) {
     const section = document.getElementById('dup-section');
+    const tbody = document.getElementById('dup-tbody');
+    tbody.innerHTML = '';  // re-render-safe (filters re-invoke this)
     if (!groups.length) { section.style.display = 'none'; return; }
     section.style.display = '';
     document.getElementById('dup-count').textContent = groups.length;
 
-    // Category -> {label, colour}; ordered by curation priority in the data already.
+    // Category -> {label, colour}.
     const CATS = {
       'org-org':     { label: 'Org ↔ Org',      color: '#b31d28' },
       'promotion':   { label: 'Personal → Org', color: '#b35900' },
       'cross-owner': { label: 'Cross-owner',          color: '#9a6700' },
       'same-owner':  { label: 'Same owner',           color: '#6a737d' },
     };
-    const tbody = document.getElementById('dup-tbody');
 
     groups.forEach(g => {
       const cat = CATS[g.category] || { label: g.category, color: '#6a737d' };

--- a/docs/index.html
+++ b/docs/index.html
@@ -295,6 +295,29 @@
     }
     code.dup-sha { font-size: 0.75rem; color: #586069; }
 
+    /* Filter bar */
+    #filters {
+      display: flex;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+      background: #fff;
+      border: 1px solid #e1e4e8;
+      border-radius: 6px;
+      padding: 0.6rem 1rem;
+      margin-bottom: 1.5rem;
+      font-size: 0.875rem;
+    }
+    #filters .filters-label {
+      color: #586069;
+      font-weight: 600;
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    #filters label { display: inline-flex; align-items: center; gap: 0.4rem; cursor: pointer; }
+    #filters .hint { margin-left: auto; color: #586069; font-size: 0.78rem; }
+
     @media (max-width: 700px) {
       #charts { grid-template-columns: 1fr; }
       #summary { flex-direction: column; }
@@ -314,6 +337,13 @@
     <button class="carousel-nav" id="carousel-prev">&#8249;</button>
     <button class="carousel-nav" id="carousel-next">&#8250;</button>
     <div class="carousel-dots" id="carousel-dots"></div>
+  </section>
+
+  <section id="filters">
+    <span class="filters-label">Filters</span>
+    <label><input type="checkbox" id="hide-test" checked> Hide test repositories</label>
+    <label><input type="checkbox" id="include-ephemeral" checked> Include ephemeral repositories</label>
+    <span class="hint" id="filter-count"></span>
   </section>
 
   <section id="summary">

--- a/docs/index.html
+++ b/docs/index.html
@@ -254,6 +254,47 @@
     }
     .carousel-dot.active { background: #fff; }
 
+    /* Duplicate-volumes panel */
+    #dup-section {
+      background: #fff;
+      border: 1px solid #e1e4e8;
+      border-radius: 6px;
+      overflow: hidden;
+      margin-bottom: 1.5rem;
+    }
+    #dup-section h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid #e1e4e8;
+      background: #fff6f0;
+    }
+    #dup-section h2 .sub {
+      font-weight: 400;
+      font-size: 0.8rem;
+      color: #586069;
+    }
+    .dup-badge {
+      display: inline-block;
+      padding: 0.15rem 0.5rem;
+      border-radius: 10px;
+      color: #fff;
+      font-size: 0.68rem;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      white-space: nowrap;
+    }
+    .org-tag {
+      font-size: 0.62rem;
+      background: #1a3a52;
+      color: #fff;
+      padding: 0 0.3rem;
+      border-radius: 3px;
+      vertical-align: middle;
+      text-transform: uppercase;
+    }
+    code.dup-sha { font-size: 0.75rem; color: #586069; }
+
     @media (max-width: 700px) {
       #charts { grid-template-columns: 1fr; }
       #summary { flex-direction: column; }
@@ -306,6 +347,23 @@
       </select>
       <div id="taxonomy-chart" style="height:240px"></div>
     </div>
+  </section>
+
+  <section id="dup-section" style="display:none">
+    <h2>Duplicate Volumes — <span id="dup-count">0</span>
+      <span class="sub">repos sharing a byte-identical source volume (same SHA-256)</span>
+    </h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Type</th>
+          <th>Repositories sharing one volume</th>
+          <th>Species</th>
+          <th>Checksum</th>
+        </tr>
+      </thead>
+      <tbody id="dup-tbody"></tbody>
+    </table>
   </section>
 
   <section id="repo-section">

--- a/scripts/drain.py
+++ b/scripts/drain.py
@@ -23,6 +23,10 @@ GITHUB_REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "")
 MAX_IDLE_CYCLES = 3
 POLL_INTERVAL = 5  # seconds
 
+# Journal schema version. Bump when the journal shape changes so sync-all re-queues
+# existing journals for a one-time backfill. v2 added sourceVolumeChecksum.
+SCHEMA_VERSION = 2
+
 GRAPHQL_QUERY = """
 query($owner: String!, $repo: String!) {
   repository(owner: $owner, name: $repo) {
@@ -101,6 +105,17 @@ def process_repo(owner, repo):
                 # so we want the last occurrence, which is from the final destination.
                 volume_size = int(line.split(":", 1)[1].strip())
 
+    # source_volume_checksum is a committed file whose content is "SHA256:<64-hex>".
+    # Journal the bare lowercase hex so duplicate-volume detection can group on it
+    # (two repos with the same digest hold byte-identical volumes).
+    source_checksum = None
+    checksum_raw = fetch_url(f"{base_url}/source_volume_checksum")
+    if checksum_raw:
+        val = checksum_raw.strip()
+        if ":" in val:
+            val = val.split(":", 1)[1].strip()
+        source_checksum = val.lower() or None
+
     try:
         sc = run(["gh", "api", f"repos/{owner}/{repo}/contents/screenshots",
                   "--jq", '[.[] | select(.name | test("\\.(png|jpg|jpeg|gif|webp)$"; "i"))] | length'])
@@ -141,7 +156,7 @@ def process_repo(owner, repo):
 
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     journal = {
-        "schemaVersion": 1,
+        "schemaVersion": SCHEMA_VERSION,
         "nameWithOwner": f"{owner}/{repo}",
         "journalUpdatedAt": now,
         "pushedAt": data["pushedAt"],
@@ -151,6 +166,7 @@ def process_repo(owner, repo):
         "screenshotCount": screenshot_count,
         "screenshotCaptions": captions,
         "volumeSize": volume_size,
+        "sourceVolumeChecksum": source_checksum,
     }
 
     out_path = Path(f"journals/{owner}^{repo}.json")

--- a/scripts/generate-dashboard.py
+++ b/scripts/generate-dashboard.py
@@ -13,6 +13,10 @@ TAXONOMY_LEVELS = ["kingdom", "phylum", "class", "order", "family", "genus"]
 # governed) as opposed to a personal repo (GitHub release asset).
 ORG_LOGIN = "MorphoDepot"
 
+# Orgs that exist purely for the module's self-test / Reload-and-Test runs — everything under
+# them is a test artifact (the self-test publishes to MorphoDepotTesting).
+TEST_ORGS = frozenset({"MorphoDepotTesting", "MorphoDepotTest"})
+
 # Duplicate-group categories, ordered by curation priority (lower = more urgent).
 DUP_CATEGORY_PRIORITY = {"org-org": 0, "promotion": 1, "cross-owner": 2, "same-owner": 3}
 
@@ -23,6 +27,22 @@ def accession_answer(accession, key):
     if isinstance(v, list) and len(v) >= 2:
         return v[1]
     return v
+
+
+def is_test_repo(name_with_owner):
+    """True for repos produced by the module's self-test / Reload-and-Test runs: anything under
+    a known testing org (MorphoDepotTesting / MorphoDepotTest), or whose name starts with
+    'test-'.  The self-test names repos two ways — `test-repo-<n>` and `test-<genus>-<species>-<n>`
+    — and publishes them to MorphoDepotTesting (see MorphoDepot.py)."""
+    owner, _, name = name_with_owner.partition("/")
+    return owner in TEST_ORGS or name.startswith("test-")
+
+
+def is_ephemeral_repo(accession):
+    """True for 'ephemeral' repos — the accession's repoType lifespan is Short-term
+    (classroom/disposable), not Archival."""
+    rt = accession_answer(accession, "repoType") or ""
+    return isinstance(rt, str) and rt.startswith("Short-term")
 
 
 def categorize_duplicate(repos):
@@ -67,7 +87,8 @@ def build_duplicate_report(checksum_to_repos):
                 "checksum": checksum,
                 "category": category,
                 "repos": [{"nameWithOwner": r["nameWithOwner"], "isOrg": r["isOrg"],
-                           "species": r["species"]} for r in unique],
+                           "species": r["species"], "isTest": r["isTest"],
+                           "isEphemeral": r["isEphemeral"]} for r in unique],
             })
     duplicate_groups.sort(key=lambda g: (DUP_CATEGORY_PRIORITY.get(g["category"], 9),
                                          g["checksum"]))
@@ -126,6 +147,9 @@ def main():
             val = accession.get(level) or "Unknown"
             taxonomy[level][val] = taxonomy[level].get(val, 0) + 1
 
+        is_test = is_test_repo(nwo)
+        is_ephemeral = is_ephemeral_repo(accession)
+
         repos_list.append({
             "nameWithOwner": nwo,
             "pushedAt": pushed_at_str,
@@ -135,6 +159,8 @@ def main():
             "screenshotCount": j.get("screenshotCount", 0),
             "screenshotCaptions": j.get("screenshotCaptions", []),
             "accession": accession,
+            "isTest": is_test,
+            "isEphemeral": is_ephemeral,
         })
 
         # Collect source-volume checksums for duplicate detection (schema v2+).
@@ -146,6 +172,8 @@ def main():
                 "owner": owner,
                 "isOrg": owner == ORG_LOGIN,
                 "species": accession_answer(accession, "species") or "Unknown",
+                "isTest": is_test,
+                "isEphemeral": is_ephemeral,
             })
 
     # Sort by most recently pushed

--- a/scripts/generate-dashboard.py
+++ b/scripts/generate-dashboard.py
@@ -9,6 +9,70 @@ from pathlib import Path
 
 TAXONOMY_LEVELS = ["kingdom", "phylum", "class", "order", "family", "genus"]
 
+# The login of the MorphoDepot organization; a repo under it is an "org" repo (S3-backed,
+# governed) as opposed to a personal repo (GitHub release asset).
+ORG_LOGIN = "MorphoDepot"
+
+# Duplicate-group categories, ordered by curation priority (lower = more urgent).
+DUP_CATEGORY_PRIORITY = {"org-org": 0, "promotion": 1, "cross-owner": 2, "same-owner": 3}
+
+
+def accession_answer(accession, key):
+    """Accession values are [question, answer] pairs; return just the answer."""
+    v = accession.get(key)
+    if isinstance(v, list) and len(v) >= 2:
+        return v[1]
+    return v
+
+
+def categorize_duplicate(repos):
+    """Classify a set of repos that share one source-volume checksum.
+
+    promotion   = the same volume in both a personal repo and the org (personal->org).
+    org-org     = two or more org repos (storage + provenance waste; highest priority).
+    same-owner  = multiple personal repos by one owner (usually benign: classroom reuse).
+    cross-owner = multiple personal repos across owners (possible attribution/reuse issue).
+    """
+    org = [r for r in repos if r["isOrg"]]
+    personal = [r for r in repos if not r["isOrg"]]
+    if org and personal:
+        return "promotion"
+    if len(org) > 1:
+        return "org-org"
+    if len({r["owner"] for r in repos}) == 1:
+        return "same-owner"
+    return "cross-owner"
+
+
+def build_duplicate_report(checksum_to_repos):
+    """Group repos by checksum; return (duplicate_groups, checksum_index).
+
+    duplicate_groups: only checksums shared by >1 repo, categorized and priority-sorted.
+    checksum_index:   every checksum -> [nameWithOwner, ...] (the published lookup index
+                      consumed by the stage/publish-time duplicate warning).
+    """
+    duplicate_groups = []
+    checksum_index = {}
+    for checksum, repos in checksum_to_repos.items():
+        # De-dup repos within a checksum (a repo should appear once); keep insertion order.
+        seen, unique = set(), []
+        for r in repos:
+            if r["nameWithOwner"] not in seen:
+                seen.add(r["nameWithOwner"])
+                unique.append(r)
+        checksum_index[checksum] = [r["nameWithOwner"] for r in unique]
+        if len(unique) > 1:
+            category = categorize_duplicate(unique)
+            duplicate_groups.append({
+                "checksum": checksum,
+                "category": category,
+                "repos": [{"nameWithOwner": r["nameWithOwner"], "isOrg": r["isOrg"],
+                           "species": r["species"]} for r in unique],
+            })
+    duplicate_groups.sort(key=lambda g: (DUP_CATEGORY_PRIORITY.get(g["category"], 9),
+                                         g["checksum"]))
+    return duplicate_groups, checksum_index
+
 
 def main():
     journals_dir = Path("journals")
@@ -22,6 +86,7 @@ def main():
     taxonomy = {level: {} for level in TAXONOMY_LEVELS}
     activity = {"last_day": 0, "last_week": 0, "last_month": 0, "last_year": 0}
     repos_list = []
+    checksum_to_repos = {}  # source-volume sha256 -> [repo meta, ...]
 
     for journal_path in sorted(journals_dir.glob("*.json")):
         try:
@@ -72,17 +137,32 @@ def main():
             "accession": accession,
         })
 
+        # Collect source-volume checksums for duplicate detection (schema v2+).
+        checksum = j.get("sourceVolumeChecksum")
+        if checksum and nwo:
+            owner = nwo.split("/", 1)[0]
+            checksum_to_repos.setdefault(checksum, []).append({
+                "nameWithOwner": nwo,
+                "owner": owner,
+                "isOrg": owner == ORG_LOGIN,
+                "species": accession_answer(accession, "species") or "Unknown",
+            })
+
     # Sort by most recently pushed
     repos_list.sort(key=lambda r: r.get("pushedAt", ""), reverse=True)
 
+    duplicate_groups, checksum_index = build_duplicate_report(checksum_to_repos)
+    generated_at = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
     data = {
-        "generatedAt": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "generatedAt": generated_at,
         "totalRepos": len(repos_list),
         "totalOpenIssues": total_open_issues,
         "totalOpenPRs": total_open_prs,
         "taxonomy": taxonomy,
         "activity": activity,
         "repos": repos_list,
+        "duplicateVolumes": duplicate_groups,
     }
 
     out_path = docs_dir / "dashboard-data.json"
@@ -90,7 +170,23 @@ def main():
         json.dump(data, f, indent=2)
         f.write("\n")
 
-    print(f"Wrote {out_path} ({len(repos_list)} repo(s))")
+    print(f"Wrote {out_path} ({len(repos_list)} repo(s), "
+          f"{len(duplicate_groups)} duplicate group(s))")
+
+    # Published checksum -> [repo] index, consumed by the extension's stage/publish-time
+    # duplicate-volume warning. Every known checksum (not just duplicates) is listed so any
+    # incoming volume can be looked up.
+    index_path = docs_dir / "volume-checksums.json"
+    with open(index_path, "w") as f:
+        json.dump({
+            "generatedAt": generated_at,
+            "schemaVersion": 2,
+            "checksums": checksum_index,
+        }, f, indent=2)
+        f.write("\n")
+
+    print(f"Wrote {index_path} ({len(checksum_index)} checksum(s))")
 
 
-main()
+if __name__ == "__main__":
+    main()

--- a/scripts/sync-all.py
+++ b/scripts/sync-all.py
@@ -16,6 +16,10 @@ from pathlib import Path
 
 GITHUB_REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "")
 
+# Keep in sync with drain.SCHEMA_VERSION. A journal whose schemaVersion is below this
+# is treated as stale, so a schema bump backfills every journal on the next sync.
+SCHEMA_VERSION = 2
+
 
 def run(cmd, check=True):
     return subprocess.run(cmd, check=check, text=True, capture_output=True)
@@ -65,9 +69,10 @@ def main():
         try:
             with open(path) as f:
                 data = json.load(f)
-            journaled_repos[nwo] = {"path": path, "pushedAt": data.get("pushedAt", "")}
+            journaled_repos[nwo] = {"path": path, "pushedAt": data.get("pushedAt", ""),
+                                    "schemaVersion": data.get("schemaVersion", 1)}
         except Exception:
-            journaled_repos[nwo] = {"path": path, "pushedAt": ""}
+            journaled_repos[nwo] = {"path": path, "pushedAt": "", "schemaVersion": 0}
 
     print(f"Found {len(journaled_repos)} existing journal file(s)")
 
@@ -79,6 +84,8 @@ def main():
             reason = "missing"
         elif journal["pushedAt"] != remote_pushed_at:
             reason = "stale"
+        elif journal.get("schemaVersion", 1) < SCHEMA_VERSION:
+            reason = "schema-upgrade"
         else:
             reason = None
 

--- a/scripts/test_duplicates.py
+++ b/scripts/test_duplicates.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Unit tests for the duplicate-volume report logic in generate-dashboard.py.
+
+Run: python3 scripts/test_duplicates.py   (no deps, no network)
+"""
+import importlib.util
+from pathlib import Path
+
+# Load the hyphenated module by path.
+_spec = importlib.util.spec_from_file_location(
+    "gen_dashboard", Path(__file__).with_name("generate-dashboard.py"))
+gd = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gd)
+
+
+def repo(nwo, species="Unknown"):
+    owner = nwo.split("/", 1)[0]
+    return {"nameWithOwner": nwo, "owner": owner, "isOrg": owner == gd.ORG_LOGIN,
+            "species": species}
+
+
+def check(name, cond):
+    print(f"  {'PASS' if cond else 'FAIL'}  {name}")
+    assert cond, name
+
+
+def test_parse_checksum_file():
+    # Mirrors drain.py: "SHA256:<hex>" -> bare lowercase hex.
+    def parse(raw):
+        val = raw.strip()
+        if ":" in val:
+            val = val.split(":", 1)[1].strip()
+        return val.lower() or None
+    check("parse strips SHA256: prefix", parse("SHA256:ABCDEF12") == "abcdef12")
+    check("parse handles trailing newline", parse("SHA256:abc\n") == "abc")
+    check("parse handles bare hex", parse("deadbeef") == "deadbeef")
+    check("parse empty -> None", parse("   ") is None)
+
+
+def test_categories():
+    check("promotion (personal+org)",
+          gd.categorize_duplicate([repo("alice/x"), repo("MorphoDepot/x")]) == "promotion")
+    check("org-org (two org repos)",
+          gd.categorize_duplicate([repo("MorphoDepot/a"), repo("MorphoDepot/b")]) == "org-org")
+    check("same-owner (one personal owner)",
+          gd.categorize_duplicate([repo("alice/a"), repo("alice/b")]) == "same-owner")
+    check("cross-owner (different personal owners)",
+          gd.categorize_duplicate([repo("alice/a"), repo("bob/b")]) == "cross-owner")
+    # promotion wins even with multiple org repos present
+    check("promotion precedence over org-org",
+          gd.categorize_duplicate([repo("alice/x"), repo("MorphoDepot/a"),
+                                   repo("MorphoDepot/b")]) == "promotion")
+
+
+def test_build_report():
+    data = {
+        "sha-dup-personal": [repo("alice/x", "Mus musculus"), repo("bob/y", "Mus musculus")],
+        "sha-promo": [repo("carol/z"), repo("MorphoDepot/z")],
+        "sha-unique": [repo("dave/only")],
+        "sha-orgorg": [repo("MorphoDepot/a"), repo("MorphoDepot/b")],
+        # same repo listed twice must collapse to one (not a duplicate)
+        "sha-self": [repo("eve/w"), repo("eve/w")],
+    }
+    groups, index = gd.build_duplicate_report(data)
+
+    by_sha = {g["checksum"]: g for g in groups}
+    check("unique sha not a duplicate group", "sha-unique" not in by_sha)
+    check("self-dup collapses, not a group", "sha-self" not in by_sha)
+    check("3 duplicate groups", len(groups) == 3)
+    check("cross-owner category", by_sha["sha-dup-personal"]["category"] == "cross-owner")
+    check("promotion category", by_sha["sha-promo"]["category"] == "promotion")
+    check("org-org category", by_sha["sha-orgorg"]["category"] == "org-org")
+
+    # index contains EVERY checksum (incl. unique + collapsed-self), each repo once
+    check("index has all 5 checksums", len(index) == 5)
+    check("self-dup index collapsed to one repo", index["sha-self"] == ["eve/w"])
+    check("unique sha in index", index["sha-unique"] == ["dave/only"])
+
+    # priority sort: org-org (0) before promotion (1) before cross-owner (2)
+    check("groups priority-sorted",
+          [g["category"] for g in groups] == ["org-org", "promotion", "cross-owner"])
+
+    # species carried through
+    check("species carried", by_sha["sha-dup-personal"]["repos"][0]["species"] == "Mus musculus")
+
+
+if __name__ == "__main__":
+    print("test_parse_checksum_file"); test_parse_checksum_file()
+    print("test_categories"); test_categories()
+    print("test_build_report"); test_build_report()
+    print("\nAll duplicate-report tests passed.")

--- a/scripts/test_duplicates.py
+++ b/scripts/test_duplicates.py
@@ -13,10 +13,10 @@ gd = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(gd)
 
 
-def repo(nwo, species="Unknown"):
+def repo(nwo, species="Unknown", isTest=False, isEphemeral=False):
     owner = nwo.split("/", 1)[0]
     return {"nameWithOwner": nwo, "owner": owner, "isOrg": owner == gd.ORG_LOGIN,
-            "species": species}
+            "species": species, "isTest": isTest, "isEphemeral": isEphemeral}
 
 
 def check(name, cond):
@@ -84,8 +84,34 @@ def test_build_report():
     check("species carried", by_sha["sha-dup-personal"]["repos"][0]["species"] == "Mus musculus")
 
 
+def test_flags():
+    check("test-repo-1234 is a test repo", gd.is_test_repo("muratmaga/test-repo-1234"))
+    check("test-<genus>-<species>-N is a test repo",
+          gd.is_test_repo("MorphoDepotTesting/test-sliceropithecus-maximus-363"))
+    check("MorphoDepotTesting/* is a test repo (delete-22)",
+          gd.is_test_repo("MorphoDepotTesting/delete-22"))
+    check("MorphoDepotTest/MRHead is a test repo", gd.is_test_repo("MorphoDepotTest/MRHead"))
+    check("test- prefix anywhere is a test repo", gd.is_test_repo("someuser/test-foo-bar-5"))
+    check("real species repo is not", not gd.is_test_repo("muratmaga/Gorilla_skull"))
+    check("'Testudo' (no hyphen) is not a test repo", not gd.is_test_repo("x/Testudo_graveyard"))
+    check("MorphoDepot/member (org, real) is not a test repo",
+          not gd.is_test_repo("MorphoDepot/member"))
+    check("ephemeral from Short-term repoType",
+          gd.is_ephemeral_repo({"repoType": ["q", "Short-term (e.g. classroom...)"]}))
+    check("not ephemeral from Archival",
+          not gd.is_ephemeral_repo({"repoType": ["q", "Archival (long-term)"]}))
+    check("not ephemeral when repoType absent", not gd.is_ephemeral_repo({}))
+    # flags propagate into duplicate-group repos
+    data = {"sha": [repo("x/test-repo-1234", isTest=True), repo("MorphoDepot/a", isEphemeral=True)]}
+    groups, _ = gd.build_duplicate_report(data)
+    reps = {r["nameWithOwner"]: r for r in groups[0]["repos"]}
+    check("isTest flag carried", reps["x/test-repo-1234"]["isTest"] is True)
+    check("isEphemeral flag carried", reps["MorphoDepot/a"]["isEphemeral"] is True)
+
+
 if __name__ == "__main__":
     print("test_parse_checksum_file"); test_parse_checksum_file()
     print("test_categories"); test_categories()
     print("test_build_report"); test_build_report()
+    print("test_flags"); test_flags()
     print("\nAll duplicate-report tests passed.")


### PR DESCRIPTION
## What

Two related additions to RepoClerk:

1. **Duplicate-volume detection** — journal each repo's source-volume SHA-256 and surface repos that share a byte-identical volume.
2. **Dashboard filters** — hide self-test repos, and a toggle for ephemeral (short-term / classroom) repos.

## Why

Source volumes are moving from GitHub release assets to JS2 object storage, alongside a two-tier org model (see the SlicerMorphoDepot changes). The same volume can legitimately land in more than one repo — e.g. a user publishes on their personal account, then re-publishes in the MorphoDepot org. RepoClerk already crawls both org and personal `topic:morphodepot` repos, so it's the natural place to detect this. (Real case from testing: `amm554/non-member` and `MorphoDepot/member` hold an identical volume.)

## Changes

**Journal schema v2** (`drain.py`): adds `sourceVolumeChecksum`, parsed from each repo's committed `SHA256:<hex>` file. `sync-all.py` treats below-schema journals as stale, so existing journals backfill their checksum on the next sync.

**Report + index** (`generate-dashboard.py`):
- `dashboard-data.json` gains a `duplicateVolumes` array — repos grouped by identical SHA-256, categorized (org-org / promotion / cross-owner / same-owner) and priority-sorted.
- New `docs/volume-checksums.json` — a SHA-256 → repo index, published via Pages, consumed by the extension's stage/publish-time duplicate warning.
- Each repo (and each repo in a duplicate group) is flagged `isTest` / `isEphemeral`.

**Dashboard** (`index.html` + `dashboard.js`):
- A "Duplicate Volumes" panel (hidden when empty).
- A filter bar with two checkboxes (default checked): "Hide test repositories" and "Include ephemeral repositories". Filtering recomputes the whole dashboard client-side (summary, charts, table, and the duplicate panel, which re-groups from the visible repos).

**Tests**: `scripts/test_duplicates.py` (no deps, no network) covers checksum parsing, SHA grouping, categorization, the published index, and the `isTest`/`isEphemeral` helpers.

## Notes for review

- `isTest` = owner in {MorphoDepotTesting, MorphoDepotTest} or name starts with `test-`.
- `isEphemeral` = accession `repoType` lifespan is "Short-term".
- The duplicate report is **report-only** — no automated action.
- The data artifacts (`dashboard-data.json`, `volume-checksums.json`) regenerate in CI on the next sync; not hand-committed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
