### PR TITLE
sync-all: hourly backstop (was every 6h)

### DIFF
--- a/.github/workflows/sync-all.yml
+++ b/.github/workflows/sync-all.yml
@@ -2,7 +2,7 @@ name: Sync All MorphoDepot Journals
 
 on:
   schedule:
-    - cron: '0 */6 * * *'   # every 6 hours
+    - cron: '23 * * * *'    # hourly (offset off the congested top-of-hour; backstop to notifyRepoClerk)
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
RepoClerk is public → Actions minutes are free, so there's no cost to running more often. Tightens the journal-freshness backstop from every 6h to hourly (offset to `:23` to dodge GitHub's top-of-hour scheduling congestion).

This is just the backstop for missed/skipped `notifyRepoClerk` drains; real-time freshness (seconds) still comes from the notify path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)