### PR TITLE
Design: near-real-time ingestion via webhooks (workshop use case)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ RepoClerk solves this by acting as a pre-computed journal of the state of all Mo
 ```
 RepoClerk/
   README.md
+  design/
+    near-realtime-ingestion.md  # webhook-based near-real-time ingestion (design note)
   journals/
     {owner}^{repo}.json       # one file per MorphoDepot repository
   docs/
@@ -37,7 +39,7 @@ RepoClerk/
     generate-dashboard.py     # reads journals/, writes docs/dashboard-data.json
   .github/
     workflows/
-      update-repo.yml         # drain loop: processes update-request issues, then regenerates dashboard
+      update-repo.yml         # drain loop: triggered by repository_dispatch (webhook receiver / client) or update-request issues; regenerates dashboard
       sync-all.yml            # cron: queues stale/missing repos, deletes removed ones, regenerates dashboard
 ```
 
@@ -158,6 +160,42 @@ gh api repos/{RepoClerkOrg}/RepoClerk/dispatches \
 
 If the RepoClerk clone is not present or `git pull` fails, MorphoDepot falls back to the existing direct GitHub API calls so the extension remains functional without RepoClerk.
 
+## How Journals Get Updated (Ingestion)
+
+A journal is (re)written by `drain.py` (via the `update-repo.yml` workflow). That workflow is
+triggered three ways, in order of importance:
+
+1. **GitHub webhook — near-real-time, primary.** An org-level webhook on the `MorphoDepot` org POSTs
+   every repo/issue/PR/release/push event to a receiver in the
+   [intake app](https://github.com/MorphoDepot/morphodepot-intake) (`POST /github/webhook`, served at
+   `join.morphodepot.org`). The receiver HMAC-verifies the delivery, keeps only repos carrying the
+   `morphodepot` topic (so infra repos are never journaled), coalesces bursts per repo over a short
+   window, and fires a `repository_dispatch` (`update-repo`) at RepoClerk. Measured latency: an action
+   on a repo → fresh journal in **~20 s**. This is what makes live workshops viable (an instructor
+   creates a repo and attendees immediately work on it). Full design + rationale:
+   [`design/near-realtime-ingestion.md`](design/near-realtime-ingestion.md).
+2. **Client `repository_dispatch` — best-effort.** The Slicer extension fires the same dispatch after
+   state-changing operations (see *Triggering a Journal Update After State Changes* above). It predates
+   the webhook and overlaps harmlessly (coalesced); it may be retired once webhooks are proven.
+3. **`sync-all` cron — hourly backstop.** Discovers missing/stale (`pushedAt` mismatch) and
+   schema-upgrade journals, queues them, and deletes journals for repos no longer live. Catches any
+   missed webhook delivery and handles initial population.
+
+All three funnel into the same `drain.py`, and all writers share the `repoclerk-writer` concurrency
+group so journal/dashboard updates serialize safely.
+
+### Webhook receiver setup (one-time)
+
+The receiver lives in the intake app; the only RepoClerk-side requirement is that `update-repo.yml`
+accepts `repository_dispatch` (it does). To (re)provision the webhook:
+
+- **Secret:** `GITHUB_WEBHOOK_SECRET` in the intake app's service env (`/etc/morphodepot-intake/env`);
+  the receiver returns 503 if it is unset and 401 on a bad/missing signature.
+- **Org webhook** (Org → Settings → Webhooks): Payload URL `https://join.morphodepot.org/github/webhook`,
+  content type `application/json`, the shared secret, and the events **Issues, Pull requests, Releases,
+  Pushes, Repositories** (or "Send me everything"). Creating it via the API needs the `admin:org_hook`
+  scope; the org UI does not.
+
 ## Key Design Decisions
 
 - **Per-repo files** (not a single combined file) to avoid write conflicts when multiple repos are updated concurrently
@@ -165,5 +203,5 @@ If the RepoClerk clone is not present or `git pull` fails, MorphoDepot falls bac
 - **Accession data embedded** in the journal so the Search tab requires only a `git pull`, not a separate HTTP fetch per repo
 - **Client-side filtering** by assignee/author — the journal stores all open issues/PRs; the client filters using its own identity
 - **`pushedAt` preserved** from GitHub so the cron job can detect staleness without fetching full issue/PR data for every repo on every run
-- **Cron as safety net** — the primary update path is on-demand dispatch; cron catches gaps and handles initial population
+- **Webhook-driven, cron as safety net** — the primary update path is the org webhook → on-demand `repository_dispatch` (push, not poll; ~20 s to a fresh journal); the hourly cron catches any missed delivery and handles initial population. See [`design/near-realtime-ingestion.md`](design/near-realtime-ingestion.md) and *How Journals Get Updated* above
 - **`viewerPermission` is NOT in the journal** — this is viewer-specific and cannot be pre-computed; `administratedRepoList()` in MorphoDepot still needs a direct `gh` API call

--- a/design/near-realtime-ingestion.md
+++ b/design/near-realtime-ingestion.md
@@ -1,0 +1,87 @@
+# Near-real-time RepoClerk ingestion (for live workshops)
+
+**Status:** design proposal for review (@pieper). Not yet implemented.
+**Latency target:** ≤ 2–3 minutes end-to-end (an instructor's action → visible in attendees' extension). Sub-second is *not* required.
+
+## The concern: live workshops are the one real-time case
+
+MorphoDepot usage is overwhelmingly **asynchronous** — a PI publishes a repo, segmentors work over
+days or weeks. There, RepoClerk's eventual consistency (cache refreshed within ~30 s on a clean
+notify, ≤ 1 h via the cron backstop) is invisible and completely fine.
+
+The one scenario where freshness matters is a **live workshop / classroom**: an instructor creates a
+repository on the spot and asks attendees to create issues and start segmenting *immediately*. In
+that burst, attendees need the new repo (Search/discovery), their new issues (Annotate tab), and
+their PRs (Review tab) to appear within a couple of minutes — otherwise people sit staring at empty
+lists during the session. This is the case worth engineering for, and ≤ 2–3 minutes is plenty.
+
+## Why it lags today (the real cause: pull-shaped ingestion)
+
+The extension's list views read RepoClerk's pre-computed journals **by design** — to avoid
+hammering GitHub with topic-wide searches as the repo count grows (the whole reason RepoClerk
+exists). Those journals are only as fresh as the last crawl, and crawling is triggered by a
+**pull/poll** mechanism:
+
+- `notifyRepoClerk` opens an `update-request` **issue** (GitHub issues used as a message queue),
+  which `update-repo.yml` consumes;
+- a `sync-all` cron sweep (now hourly) as a backstop;
+- and the `repoclerk-writer` concurrency lock can **drop** a triggered run instead of queuing it
+  (observed in testing: an `update-request` issue was *skipped*, so that refresh waited for the
+  cron).
+
+So the latency and the unreliability live entirely in the **trigger** mechanism — not in the read
+path, which is fine and should stay the single, uniform source.
+
+## Rejected alternative: client-side source switching
+
+A tempting quick fix is to special-case the active/workshop repo in the **extension** — roughly
+`if active_repo: query GitHub live; else: read RepoClerk`. We reject this: it's a band-aid that
+scatters source-selection logic through the client, teaches the client to distrust the cache, needs
+a per-repo "active repo" field, and only helps the one hand-entered repo. The right fix makes the
+cache *correct/fresh*, so the read path stays uniform and untouched.
+
+## Proposed design: push-shaped ingestion via GitHub webhooks
+
+Replace the poll/issue-queue trigger with a GitHub **org webhook**, so every change is pushed to
+RepoClerk within seconds, reliably, for **all** repos and event types — with **no extension change**.
+
+1. **Org webhook** on `MorphoDepot` for `repository`, `issues`, `pull_request`, `release`, `push`.
+   GitHub delivers each event to an HTTPS endpoint within ~1 s, with automatic delivery retries.
+2. **Receiver = the intake app** (`morphodepot-intake`, already an always-on FastAPI service on JS2
+   that holds the GitHub App credentials). Add one endpoint, `POST /github/webhook`, that:
+   - verifies the `X-Hub-Signature-256` HMAC against a shared secret;
+   - extracts the affected repo's `nameWithOwner`;
+   - triggers a journal refresh for that repo via **`repository_dispatch`** (`event_type:
+     update-repo`) to `MorphoDepot/RepoClerk` — which `update-repo.yml` already accepts.
+3. **Coalesce** events per-repo over a short window (≈ 5–10 s) so a burst (30 attendees acting at
+   once) collapses into one drain instead of 30.
+
+**End-to-end latency:** webhook delivery (~1 s) + dispatch + the existing drain Action (~25–30 s) ≈
+**well under a minute** — comfortably inside the 2–3 min target.
+
+## What this buys
+
+- **No extension change.** `issueList` / `prList` / Search keep reading RepoClerk uniformly — no
+  active-repo field, no `if/then` source switch.
+- **Uniform freshness (~seconds) for every repo and every event**, not just a workshop repo.
+- **Eliminates two kludges at once:** the issue-as-message-queue *and* the concurrency-skip
+  fragility — push + coalesce + GitHub's delivery retries replace poll + drop + cron-catch-up.
+- **Cron stays as the safety net** (hourly) for any missed delivery.
+
+## Components / work
+
+| Where | Change |
+|---|---|
+| **intake app** | new `POST /github/webhook` (HMAC verify + per-repo coalesce + `repository_dispatch`); a `GITHUB_WEBHOOK_SECRET` in the env |
+| **RepoClerk** | none required — `update-repo.yml` already accepts `repository_dispatch`. Optionally retire the `notifyRepoClerk` issue-queue once webhooks are proven (keep the cron backstop) |
+| **org (one-time, owner)** | add the org webhook: URL = the intake app, the shared secret, the 5 event types |
+| **extension** | **none** |
+
+## Tradeoffs
+
+- Adds a webhook secret + signature verification, and a one-time org-admin step (org owner).
+- The intake server becomes load-bearing for freshness — but it already owns upload, the control
+  plane, and the GC, so this is consistent with its role, not new attack surface.
+- Near-real-time, not instant: the drain still runs as an Action (~30 s). If sub-second were ever
+  needed, the receiver could write the journal *directly* (it has the App token + boto3), at the
+  cost of a second journaling code path — unnecessary for the ≤ 3 min target.

--- a/design/near-realtime-ingestion.md
+++ b/design/near-realtime-ingestion.md
@@ -1,6 +1,6 @@
 # Near-real-time RepoClerk ingestion (for live workshops)
 
-**Status:** design proposal for review (@pieper). Not yet implemented.
+**Status:** receiver **implemented + deployed** (`morphodepot-intake#18`). One manual step remains — creating the org webhook (needs the `admin:org_hook` scope). Design still open for @pieper's review; see *Implementation status* below.
 **Latency target:** ≤ 2–3 minutes end-to-end (an instructor's action → visible in attendees' extension). Sub-second is *not* required.
 
 ## The concern: live workshops are the one real-time case
@@ -76,6 +76,22 @@ RepoClerk within seconds, reliably, for **all** repos and event types — with *
 | **RepoClerk** | none required — `update-repo.yml` already accepts `repository_dispatch`. Optionally retire the `notifyRepoClerk` issue-queue once webhooks are proven (keep the cron backstop) |
 | **org (one-time, owner)** | add the org webhook: URL = the intake app, the shared secret, the 5 event types |
 | **extension** | **none** |
+
+## Implementation status
+
+Built per this spec in **`morphodepot-intake#18`** (`POST /github/webhook`):
+
+- **Done & deployed** to `join.morphodepot.org`: HMAC verification (`X-Hub-Signature-256`); the
+  `morphodepot`-topic filter (infra repos like RepoClerk / onboarding-records are never journaled,
+  which also prevents a dashboard-push → webhook → dispatch loop); `ping` → pong; skip on
+  `repository` deleted/archived/privatized; per-repo asyncio debounce (`webhook_coalesce_seconds`,
+  default 8 s); App-token `repository_dispatch` to RepoClerk. `GITHUB_WEBHOOK_SECRET` is provisioned
+  in the service env; the endpoint is live (returns 401 to unsigned posts, 503 if unconfigured).
+  11 unit tests (`tests/test_github_webhook.py`) cover HMAC, filtering, coalescing, and the dispatch
+  path.
+- **Remaining (one-time, org owner):** create the org webhook → `https://join.morphodepot.org/github/webhook`,
+  content-type JSON, the five events, with the shared secret. Requires the `admin:org_hook` scope.
+- **No RepoClerk code change** was needed — `update-repo.yml` already accepts the dispatch.
 
 ## Tradeoffs
 

--- a/design/near-realtime-ingestion.md
+++ b/design/near-realtime-ingestion.md
@@ -1,6 +1,6 @@
 # Near-real-time RepoClerk ingestion (for live workshops)
 
-**Status:** receiver **implemented + deployed** (`morphodepot-intake#18`). One manual step remains — creating the org webhook (needs the `admin:org_hook` scope). Design still open for @pieper's review; see *Implementation status* below.
+**Status:** **implemented, deployed, and verified end-to-end** (`morphodepot-intake#18`). The org webhook is live; an issue created on a data repo appeared in its RepoClerk journal in **~20 s**. Open for @pieper's review; see *Implementation status* below.
 **Latency target:** ≤ 2–3 minutes end-to-end (an instructor's action → visible in attendees' extension). Sub-second is *not* required.
 
 ## The concern: live workshops are the one real-time case
@@ -89,8 +89,11 @@ Built per this spec in **`morphodepot-intake#18`** (`POST /github/webhook`):
   in the service env; the endpoint is live (returns 401 to unsigned posts, 503 if unconfigured).
   11 unit tests (`tests/test_github_webhook.py`) cover HMAC, filtering, coalescing, and the dispatch
   path.
-- **Remaining (one-time, org owner):** create the org webhook → `https://join.morphodepot.org/github/webhook`,
-  content-type JSON, the five events, with the shared secret. Requires the `admin:org_hook` scope.
+- **Org webhook: live** (created via the org UI). Verified end-to-end 2026-06-19 (UTC): `gh issue create`
+  on `MorphoDepot/multipart` → a dispatch-driven `update-repo` run → journal commit with the new issue,
+  **~20 s** from issue to fresh journal. Real GitHub payloads carry `repository.topics`, so the topic
+  filter works on live deliveries. (Worth confirming the hook subscribes to all five events / "send me
+  everything" — the `issues` path is proven; the receiver treats all five identically.)
 - **No RepoClerk code change** was needed — `update-repo.yml` already accepts the dispatch.
 
 ## Tradeoffs


### PR DESCRIPTION
**Design proposal for your review, @pieper — spec only, nothing implemented yet.** Full note: `design/near-realtime-ingestion.md`.

## The concern: live workshops
Normal MorphoDepot usage is async (publish a repo; segmentors work over days) and the current RepoClerk freshness (~30 s on a clean notify, ≤ 1 h via cron) is invisible there. The **one** case where it bites is a **live workshop/classroom**: an instructor creates a repo on the spot and asks attendees to create issues and start segmenting *immediately*. They need the new repo + their new issues + PRs to show up in the extension's RepoClerk-backed lists within a couple of minutes, or they're stuck on empty lists. **Target: ≤ 2–3 min** end-to-end (sub-second not needed).

## Why it lags
The lag is entirely in the **trigger** mechanism, not the read path: `notifyRepoClerk` opens an `update-request` *issue* (issues-as-queue) consumed by `update-repo.yml`, plus the hourly `sync-all` cron — and the `repoclerk-writer` concurrency lock can *drop* a triggered run (we saw a skipped `update-request` issue in testing, so that refresh waited for the cron).

## Proposed fix: push, not poll
Org **webhook** (`repository`, `issues`, `pull_request`, `release`, `push`) → the always-on **intake app** verifies the HMAC and fires `repository_dispatch` to RepoClerk (which `update-repo.yml` already accepts) → existing drain. Coalesce per-repo over ~5–10 s for bursts. ≈ under a minute end-to-end.

**Why this over a client-side `if active_repo: live else: cache` switch:** that's a band-aid that teaches the client to distrust the cache. Fixing ingestion keeps the read path uniform and untouched — **no extension change** — and gives near-real-time freshness for *every* repo/event, while also retiring the issue-as-queue and the concurrency-skip fragility. Cron stays as the backstop.

Components, tradeoffs, and the (small) work breakdown are in the design doc. Curious whether you'd prefer the receiver to live in the intake app (proposed) vs. somewhere closer to RepoClerk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)