### PR TITLE
Dashboard: classify Archival by repo owner (MorphoDepot org), default to it

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -29,20 +29,29 @@
   const taxonomyChart = echarts.init(document.getElementById('taxonomy-chart'));
   const taxSelect = document.getElementById('tax-level');
 
-  // --- Filters: "Hide test repositories" / "Include ephemeral repositories" ---
+  // --- Filters: "Hide test repositories" / "Include personal repositories" ---
   const hideTestCb = document.getElementById('hide-test');
-  const includeEphemeralCb = document.getElementById('include-ephemeral');
+  const includePersonalCb = document.getElementById('include-personal');
   const filterCountEl = document.getElementById('filter-count');
   const DUP_CATEGORY_PRIORITY = { 'org-org': 0, 'promotion': 1, 'cross-owner': 2, 'same-owner': 3 };
 
   hideTestCb.addEventListener('change', renderAll);
-  includeEphemeralCb.addEventListener('change', renderAll);
+  includePersonalCb.addEventListener('change', renderAll);
   taxSelect.addEventListener('change', () => renderTaxonomy(data.repos.filter(repoVisible)));
   renderAll();
 
+  // Repository tier is OWNER-based: "Archival" iff owned by the MorphoDepot org (the gated, reviewed
+  // home), else "Personal".  Falls back to computing from nameWithOwner when isArchival is absent
+  // (e.g. dashboard-data.json regenerated before the field was added), so there's no empty-list gap.
+  function repoIsArchival(r) {
+    return (r.isArchival !== undefined)
+      ? r.isArchival
+      : (r.nameWithOwner || '').split('/')[0] === 'MorphoDepot';
+  }
+
   function repoVisible(r) {
-    if (hideTestCb.checked && r.isTest) return false;          // hide reload-and-test repos
-    if (!includeEphemeralCb.checked && r.isEphemeral) return false;  // optionally hide ephemeral
+    if (hideTestCb.checked && r.isTest) return false;                     // hide reload-and-test repos
+    if (!includePersonalCb.checked && !repoIsArchival(r)) return false;   // default: Archival (org) only
     return true;
   }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -408,7 +408,7 @@
   <section id="filters">
     <span class="filters-label">Filters</span>
     <label><input type="checkbox" id="hide-test" checked> Hide test repositories</label>
-    <label><input type="checkbox" id="include-ephemeral"> Include ephemeral repositories</label>
+    <label><input type="checkbox" id="include-personal"> Include personal repositories</label>
     <span class="hint" id="filter-count"></span>
   </section>
 

--- a/scripts/generate-dashboard.py
+++ b/scripts/generate-dashboard.py
@@ -209,6 +209,11 @@ def main():
 
         is_test = is_test_repo(nwo)
         is_ephemeral = is_ephemeral_repo(accession)
+        # Repository tier is OWNER-based, not the self-declared accession repoType: "Archival" iff the
+        # repo is owned by the MorphoDepot org (the gated, reviewed home), else "Personal".  This is
+        # authoritative -- a personal-account repo that self-declared "Archival" (isEphemeral stays
+        # False) is still correctly Personal here.
+        is_archival = nwo.split("/", 1)[0] == ORG_LOGIN
 
         repos_list.append({
             "nameWithOwner": nwo,
@@ -219,6 +224,7 @@ def main():
             "screenshotCount": j.get("screenshotCount", 0),
             "screenshotCaptions": j.get("screenshotCaptions", []),
             "accession": accession,
+            "isArchival": is_archival,
             "isTest": is_test,
             "isEphemeral": is_ephemeral,
         })


### PR DESCRIPTION
Implements the RepoClerk half of the coupled owner-based-classification work (#427; extension half: SlicerMorph/SlicerMorphoDepot#193 / PR #194).

## Problem
The dashboard's tier distinction rode the **self-declared accession `repoType`** (`isEphemeral` = "Short-term"), so a personal-account repo that *chose* "Archival" was shown as if archival. Today **~65 of 67** indexed repos are personal-account, pre-org test repos in accounts we don't control. Since archival creation is now gated to the MorphoDepot org, the authoritative signal is the **owner**.

## Change
- **`generate-dashboard.py`** — emit an owner-based **`isArchival`** (`owner == MorphoDepot`, via the existing `ORG_LOGIN`) on every repo, alongside `isTest`/`isEphemeral`.
- **`index.html` / `dashboard.js`** — replace the self-declared **"Include ephemeral repositories"** filter with an owner-based **"Include personal repositories"** (default **OFF**). So the dashboard shows **only Archival (org) repos by default**; personal are one checkbox away. `dashboard.js` falls back to computing the tier from `nameWithOwner` when `isArchival` is absent, so there's **no empty-list gap** before the next data regen.

## Verified (live run of the generator)
`67 repos -> 2 archival` (`MorphoDepot/mus-musculus-skull`, `MorphoDepot/mus-musculus-E15`) `/ 65 personal`. Every entry gets the `isArchival` key.

## Backward compatibility
- `isArchival` is an **additive** JSON field — no journal-schema change; old consumers ignore it.
- The accession `repoType` and `isEphemeral` are left intact (still emitted).
- The front-end fallback means the change is correct immediately on merge, even before `dashboard-data.json` is regenerated with the new field.

## Note on the extension coupling
The extension's Search does **not** read `dashboard-data.json` — it reads the raw journals and applies its own owner check (PR #194). So this dashboard change and the extension change are independent halves; both are needed.

## Open decision (from #427)
This defaults to **hide personal, one-click to include** (not fully hidden, not a separate section). Grandfather allowlist deferred — say the word if you want legit pre-org personal datasets kept as archival.