### PR TITLE
Dashboard: move charts to the bottom of the page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -427,24 +427,6 @@
     </div>
   </section>
 
-  <section id="charts">
-    <div class="chart-card">
-      <div id="activity-chart" style="height:280px"></div>
-    </div>
-    <div class="chart-card">
-      <label for="tax-level">Taxonomic level:</label>
-      <select id="tax-level">
-        <option value="kingdom">Kingdom</option>
-        <option value="phylum">Phylum</option>
-        <option value="class">Class</option>
-        <option value="order">Order</option>
-        <option value="family">Family</option>
-        <option value="genus">Genus</option>
-      </select>
-      <div id="taxonomy-chart" style="height:240px"></div>
-    </div>
-  </section>
-
   <section id="collections-section" style="display:none">
     <h2>Collections <span class="sub">— curated groupings of repositories</span></h2>
     <div class="collection-grid" id="collections-grid"></div>
@@ -481,6 +463,24 @@
       </thead>
       <tbody id="repo-tbody"></tbody>
     </table>
+  </section>
+
+  <section id="charts">
+    <div class="chart-card">
+      <div id="activity-chart" style="height:280px"></div>
+    </div>
+    <div class="chart-card">
+      <label for="tax-level">Taxonomic level:</label>
+      <select id="tax-level">
+        <option value="kingdom">Kingdom</option>
+        <option value="phylum">Phylum</option>
+        <option value="class">Class</option>
+        <option value="order">Order</option>
+        <option value="family">Family</option>
+        <option value="genus">Genus</option>
+      </select>
+      <div id="taxonomy-chart" style="height:240px"></div>
+    </div>
   </section>
 
   <div id="collection-modal" class="cm-overlay" style="display:none">


### PR DESCRIPTION
Moves the `#charts` section (Repository Activity + taxonomy pie) from **right below the carousel** to the **bottom of the page**, after the repo table.

Motivation: with the archival-only default the charts are sparse (2-3 repos, mostly "Unknown") yet took the prime spot under the carousel. New `<main>` order: carousel → filters → summary → collections → duplicates → repo table → **charts**.

HTML-only reorder — the chart element IDs (`activity-chart`, `taxonomy-chart`, `tax-level`) and all `dashboard.js` wiring are unchanged, so rendering/behavior is identical, just relocated.