### PR TITLE
Exclude test/demo repos from the dashboard carousel

### DIFF
--- a/docs/dashboard-data.json
+++ b/docs/dashboard-data.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-17T03:43:03Z",
+  "generatedAt": "2026-07-17T04:02:03Z",
   "totalRepos": 67,
   "totalOpenIssues": 119,
   "totalOpenPRs": 65,
@@ -542,7 +542,7 @@
         "fileFormatVersion": 2
       },
       "isArchival": false,
-      "isTest": false,
+      "isTest": true,
       "isEphemeral": true
     },
     {
@@ -2034,7 +2034,7 @@
         "fileFormatVersion": 2
       },
       "isArchival": false,
-      "isTest": false,
+      "isTest": true,
       "isEphemeral": true
     },
     {
@@ -3064,7 +3064,7 @@
         "fileFormatVersion": 2
       },
       "isArchival": false,
-      "isTest": false,
+      "isTest": true,
       "isEphemeral": true
     },
     {
@@ -3151,7 +3151,7 @@
         "fileFormatVersion": 2
       },
       "isArchival": false,
-      "isTest": false,
+      "isTest": true,
       "isEphemeral": true
     },
     {
@@ -3236,7 +3236,7 @@
         "fileFormatVersion": 2
       },
       "isArchival": false,
-      "isTest": false,
+      "isTest": true,
       "isEphemeral": true
     },
     {
@@ -3410,7 +3410,7 @@
         "fileFormatVersion": 2
       },
       "isArchival": false,
-      "isTest": false,
+      "isTest": true,
       "isEphemeral": true
     },
     {
@@ -3497,7 +3497,7 @@
         "fileFormatVersion": 2
       },
       "isArchival": false,
-      "isTest": false,
+      "isTest": true,
       "isEphemeral": true
     },
     {
@@ -3667,7 +3667,7 @@
         "fileFormatVersion": 2
       },
       "isArchival": false,
-      "isTest": false,
+      "isTest": true,
       "isEphemeral": true
     },
     {
@@ -3752,7 +3752,7 @@
         "fileFormatVersion": 2
       },
       "isArchival": false,
-      "isTest": false,
+      "isTest": true,
       "isEphemeral": true
     },
     {
@@ -3839,7 +3839,7 @@
         "fileFormatVersion": 2
       },
       "isArchival": false,
-      "isTest": false,
+      "isTest": true,
       "isEphemeral": true
     },
     {
@@ -5621,14 +5621,14 @@
           "nameWithOwner": "Jwyneken/SICB_sample",
           "isOrg": false,
           "species": "Homo sapiens",
-          "isTest": false,
+          "isTest": true,
           "isEphemeral": true
         },
         {
           "nameWithOwner": "MichaelBennington/Bennington_SICB2026_MRIHead",
           "isOrg": false,
           "species": "Homo sapiens",
-          "isTest": false,
+          "isTest": true,
           "isEphemeral": true
         },
         {
@@ -5642,7 +5642,7 @@
           "nameWithOwner": "annikadawley/SICB_Practice_Repository",
           "isOrg": false,
           "species": "Homo sapiens",
-          "isTest": false,
+          "isTest": true,
           "isEphemeral": true
         },
         {
@@ -5656,14 +5656,14 @@
           "nameWithOwner": "cgmena/Cesar_SICB_2026",
           "isOrg": false,
           "species": "Homo sapiens",
-          "isTest": false,
+          "isTest": true,
           "isEphemeral": true
         },
         {
           "nameWithOwner": "kforsgren-1112013/KLF_SICB_2026",
           "isOrg": false,
           "species": "Homo sapiens",
-          "isTest": false,
+          "isTest": true,
           "isEphemeral": true
         },
         {
@@ -5677,21 +5677,21 @@
           "nameWithOwner": "nahrweiler/natasha_sicb_2026",
           "isOrg": false,
           "species": "Homo sapiens",
-          "isTest": false,
+          "isTest": true,
           "isEphemeral": true
         },
         {
           "nameWithOwner": "ramenegaz/MRhead_sample",
           "isOrg": false,
           "species": "Homo sapiens",
-          "isTest": false,
+          "isTest": true,
           "isEphemeral": true
         },
         {
           "nameWithOwner": "sunnyjsh/Sunny_sicb2",
           "isOrg": false,
           "species": "Pteronitella humanensis",
-          "isTest": false,
+          "isTest": true,
           "isEphemeral": true
         }
       ]

--- a/docs/dashboard-data.json
+++ b/docs/dashboard-data.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-05T16:31:00Z",
+  "generatedAt": "2026-07-17T03:43:03Z",
   "totalRepos": 67,
   "totalOpenIssues": 119,
   "totalOpenPRs": 65,
@@ -25,8 +25,8 @@
   },
   "activity": {
     "last_day": 0,
-    "last_week": 3,
-    "last_month": 10,
+    "last_week": 0,
+    "last_month": 6,
     "last_year": 64
   },
   "repos": [
@@ -1949,7 +1949,7 @@
         "fileFormatVersion": 2
       },
       "isArchival": false,
-      "isTest": false,
+      "isTest": true,
       "isEphemeral": true
     },
     {
@@ -2890,7 +2890,7 @@
         "fileFormatVersion": 2
       },
       "isArchival": false,
-      "isTest": false,
+      "isTest": true,
       "isEphemeral": true
     },
     {
@@ -2977,7 +2977,7 @@
         "fileFormatVersion": 2
       },
       "isArchival": false,
-      "isTest": false,
+      "isTest": true,
       "isEphemeral": true
     },
     {
@@ -3323,7 +3323,7 @@
         "fileFormatVersion": 2
       },
       "isArchival": false,
-      "isTest": false,
+      "isTest": true,
       "isEphemeral": true
     },
     {
@@ -4607,7 +4607,7 @@
         "fileFormatVersion": 2
       },
       "isArchival": false,
-      "isTest": false,
+      "isTest": true,
       "isEphemeral": true
     },
     {
@@ -5482,7 +5482,7 @@
       "screenshotCaptions": [],
       "accession": {},
       "isArchival": false,
-      "isTest": false,
+      "isTest": true,
       "isEphemeral": false
     },
     {
@@ -5554,7 +5554,7 @@
         "scanSpacing": "(0.07303892000000001, 0.07303892000000001, 0.07303892000000001)"
       },
       "isArchival": false,
-      "isTest": false,
+      "isTest": true,
       "isEphemeral": false
     }
   ],
@@ -5567,7 +5567,7 @@
           "nameWithOwner": "leighamarielynch-hash/test",
           "isOrg": false,
           "species": "Alligator darwini",
-          "isTest": false,
+          "isTest": true,
           "isEphemeral": true
         },
         {
@@ -5635,7 +5635,7 @@
           "nameWithOwner": "Peter-T-Ruehr/MRI_test_head",
           "isOrg": false,
           "species": "Homo sapiens",
-          "isTest": false,
+          "isTest": true,
           "isEphemeral": true
         },
         {
@@ -5649,7 +5649,7 @@
           "nameWithOwner": "brendanlatham/Demo_HumanHead",
           "isOrg": false,
           "species": "Homo sapiens",
-          "isTest": false,
+          "isTest": true,
           "isEphemeral": true
         },
         {
@@ -5670,7 +5670,7 @@
           "nameWithOwner": "khurds137-beep/MRI_demo_for_workshop",
           "isOrg": false,
           "species": "Homo sapiens",
-          "isTest": false,
+          "isTest": true,
           "isEphemeral": true
         },
         {

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -15,8 +15,9 @@
   document.getElementById('generated-at').textContent =
     new Date(data.generatedAt).toLocaleString();
 
-  // --- Carousel (all repos; screenshot-bearing only) ---
-  buildCarousel(data.repos);
+  // --- Carousel (screenshot-bearing repos only; test/demo throwaways never showcase) ---
+  // Personal repos ARE shown here (unlike the default table view) — only isTest repos are dropped.
+  buildCarousel(data.repos.filter(r => !r.isTest));
 
   // --- Collections (curated "repo of repos"; rendered once, independent of the repo filters) ---
   let cmSlides = [];

--- a/docs/index.html
+++ b/docs/index.html
@@ -407,7 +407,7 @@
 
   <section id="filters">
     <span class="filters-label">Filters</span>
-    <label><input type="checkbox" id="hide-test" checked> Hide test repositories</label>
+    <label><input type="checkbox" id="hide-test" checked> Hide test/demo repositories</label>
     <label><input type="checkbox" id="include-personal"> Include personal repositories</label>
     <span class="hint" id="filter-count"></span>
   </section>

--- a/docs/volume-checksums.json
+++ b/docs/volume-checksums.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-05T16:31:00Z",
+  "generatedAt": "2026-07-17T03:43:03Z",
   "schemaVersion": 2,
   "checksums": {
     "dee3e37c7faa4930b4b31c5bce7b3859eedb6b61061be9b8dd798340cf3a50cf": [

--- a/docs/volume-checksums.json
+++ b/docs/volume-checksums.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-17T03:43:03Z",
+  "generatedAt": "2026-07-17T04:02:03Z",
   "schemaVersion": 2,
   "checksums": {
     "dee3e37c7faa4930b4b31c5bce7b3859eedb6b61061be9b8dd798340cf3a50cf": [

--- a/scripts/generate-dashboard.py
+++ b/scripts/generate-dashboard.py
@@ -23,6 +23,13 @@ TEST_ORGS = frozenset({"MorphoDepotTesting", "MorphoDepotTest"})
 # account's scratch repo).  Matched case-insensitively on the full owner/name.
 EXCLUDED_REPOS = frozenset({"amm554/non-member"})
 
+# Whole-name-token words that mark a repo as a throwaway (test / demo / teaching / conference
+# artifact): never showcase it, and don't count it as a dataset repo.  Matched as a WORD (via
+# _name_tokens), so real taxa/collections are safe: 'Testudo' (tortoise), 'Demospongiae' (sponge),
+# and the plural 'Museum_samples' all keep their real status while 'MRhead_sample' does not.  Note
+# 'sicb' targets the SICB-conference workshop repos ("Society for Integrative & Comparative Biology").
+_EXCLUDED_NAME_WORDS = frozenset({"test", "demo", "sample", "sicb", "workshop", "practice"})
+
 # Duplicate-group categories, ordered by curation priority (lower = more urgent).
 DUP_CATEGORY_PRIORITY = {"org-org": 0, "promotion": 1, "cross-owner": 2, "same-owner": 3}
 
@@ -46,14 +53,6 @@ def _name_tokens(name):
     return [t.lower() for t in tokens]
 
 
-# Whole-name-token words that mark a repo as a throwaway (test / demo / teaching / conference
-# artifact): never showcase it, and don't count it as a dataset repo.  Matched as a WORD (via
-# _name_tokens), so real taxa/collections are safe: 'Testudo' (tortoise), 'Demospongiae' (sponge),
-# and the plural 'Museum_samples' all keep their real status while 'MRhead_sample' does not.  Note
-# 'sicb' targets the SICB-conference workshop repos ("Society for Integrative & Comparative Biology").
-_EXCLUDED_NAME_WORDS = frozenset({"test", "demo", "sample", "sicb", "workshop", "practice"})
-
-
 def is_test_repo(name_with_owner):
     """True for throwaway repos that should never showcase and don't count as dataset repos:
       * anything under a known testing org (MorphoDepotTesting / MorphoDepotTest),
@@ -68,6 +67,8 @@ def is_test_repo(name_with_owner):
         return True
     if name_with_owner.lower() in EXCLUDED_REPOS:
         return True
+    # Word-match the name only; owner-based exclusions are handled by TEST_ORGS above (so a user
+    # whose login contains "test" doesn't get all their real repos hidden).
     return not _EXCLUDED_NAME_WORDS.isdisjoint(_name_tokens(name))
 
 

--- a/scripts/generate-dashboard.py
+++ b/scripts/generate-dashboard.py
@@ -15,8 +15,13 @@ TAXONOMY_LEVELS = ["kingdom", "phylum", "class", "order", "family", "genus"]
 ORG_LOGIN = "MorphoDepot"
 
 # Orgs that exist purely for the module's self-test / Reload-and-Test runs — everything under
-# them is a test artifact (the self-test publishes to MorphoDepotTesting).
+# them is a test artifact (the self-test publishes to MorphoDepotTesting; MorphoDepotTest holds
+# hand-run tests).  Anything owned by one of these is auto-excluded, name notwithstanding.
 TEST_ORGS = frozenset({"MorphoDepotTesting", "MorphoDepotTest"})
+
+# Specific repos to exclude that carry no give-away word in the name (e.g. the SlicerMorph test
+# account's scratch repo).  Matched case-insensitively on the full owner/name.
+EXCLUDED_REPOS = frozenset({"amm554/non-member"})
 
 # Duplicate-group categories, ordered by curation priority (lower = more urgent).
 DUP_CATEGORY_PRIORITY = {"org-org": 0, "promotion": 1, "cross-owner": 2, "same-owner": 3}
@@ -41,19 +46,27 @@ def _name_tokens(name):
     return [t.lower() for t in tokens]
 
 
-# Whole-name-token words that mark a repo as a throwaway: never showcase it, and don't count it
-# as a dataset repo.  Matched as a WORD (via _name_tokens), so 'Testudo'/'Demospongiae' are safe.
-_EXCLUDED_NAME_WORDS = frozenset({"test", "demo"})
+# Whole-name-token words that mark a repo as a throwaway (test / demo / teaching / conference
+# artifact): never showcase it, and don't count it as a dataset repo.  Matched as a WORD (via
+# _name_tokens), so real taxa/collections are safe: 'Testudo' (tortoise), 'Demospongiae' (sponge),
+# and the plural 'Museum_samples' all keep their real status while 'MRhead_sample' does not.  Note
+# 'sicb' targets the SICB-conference workshop repos ("Society for Integrative & Comparative Biology").
+_EXCLUDED_NAME_WORDS = frozenset({"test", "demo", "sample", "sicb", "workshop", "practice"})
 
 
 def is_test_repo(name_with_owner):
-    """True for throwaway repos that should never showcase: anything under a known testing org
-    (MorphoDepotTesting / MorphoDepotTest), or whose name contains the whole word 'test' or 'demo'
-    (case-insensitive).  Catches the module's self-test names (`test-repo-<n>`,
-    `test-<genus>-<species>-<n>`, published to MorphoDepotTesting) as well as user-named try-outs
-    (`MRI_test_head`, `CDHumanTest`, `Demo_HumanHead`, `MRI_demo_for_workshop`)."""
+    """True for throwaway repos that should never showcase and don't count as dataset repos:
+      * anything under a known testing org (MorphoDepotTesting / MorphoDepotTest),
+      * an explicitly listed one-off (EXCLUDED_REPOS), or
+      * a name containing the whole word 'test', 'demo', 'sample', 'sicb', 'workshop', or
+        'practice' (case-insensitive, word-boundary aware).
+    Catches the module's self-test names (`test-repo-<n>`, `test-<genus>-<species>-<n>`) plus
+    user-named try-outs / teaching / conference repos (`MRI_test_head`, `CDHumanTest`,
+    `Demo_HumanHead`, `SICB_sample`, `KLF_SICB_2026`, `Dasyuridae_Workshop`, `MRhead_sample`)."""
     owner, _, name = name_with_owner.partition("/")
     if owner in TEST_ORGS:
+        return True
+    if name_with_owner.lower() in EXCLUDED_REPOS:
         return True
     return not _EXCLUDED_NAME_WORDS.isdisjoint(_name_tokens(name))
 

--- a/scripts/generate-dashboard.py
+++ b/scripts/generate-dashboard.py
@@ -4,6 +4,7 @@ Generate docs/dashboard-data.json from all journal files.
 The static docs/index.html loads this file via fetch().
 """
 import json
+import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -29,13 +30,32 @@ def accession_answer(accession, key):
     return v
 
 
+def _name_tokens(name):
+    """Split a repo name into lowercase word tokens, breaking on separators (``_ - .`` etc.),
+    digit boundaries, AND camelCase humps — so ``CDHumanTest`` -> ['cd', 'human', 'test'] and
+    ``MRI_test_head`` -> ['mri', 'test', 'head'].  This lets us match a whole word 'test'/'demo'
+    without also flagging species like 'Testudo' (a tortoise) or 'Demospongiae' (a sponge)."""
+    tokens = []
+    for part in re.split(r"[^A-Za-z0-9]+", name):
+        tokens += re.findall(r"[A-Z]+(?![a-z])|[A-Z][a-z]*|[a-z]+|[0-9]+", part)
+    return [t.lower() for t in tokens]
+
+
+# Whole-name-token words that mark a repo as a throwaway: never showcase it, and don't count it
+# as a dataset repo.  Matched as a WORD (via _name_tokens), so 'Testudo'/'Demospongiae' are safe.
+_EXCLUDED_NAME_WORDS = frozenset({"test", "demo"})
+
+
 def is_test_repo(name_with_owner):
-    """True for repos produced by the module's self-test / Reload-and-Test runs: anything under
-    a known testing org (MorphoDepotTesting / MorphoDepotTest), or whose name starts with
-    'test-'.  The self-test names repos two ways — `test-repo-<n>` and `test-<genus>-<species>-<n>`
-    — and publishes them to MorphoDepotTesting (see MorphoDepot.py)."""
+    """True for throwaway repos that should never showcase: anything under a known testing org
+    (MorphoDepotTesting / MorphoDepotTest), or whose name contains the whole word 'test' or 'demo'
+    (case-insensitive).  Catches the module's self-test names (`test-repo-<n>`,
+    `test-<genus>-<species>-<n>`, published to MorphoDepotTesting) as well as user-named try-outs
+    (`MRI_test_head`, `CDHumanTest`, `Demo_HumanHead`, `MRI_demo_for_workshop`)."""
     owner, _, name = name_with_owner.partition("/")
-    return owner in TEST_ORGS or name.startswith("test-")
+    if owner in TEST_ORGS:
+        return True
+    return not _EXCLUDED_NAME_WORDS.isdisjoint(_name_tokens(name))
 
 
 def is_ephemeral_repo(accession):

--- a/scripts/test_duplicates.py
+++ b/scripts/test_duplicates.py
@@ -92,8 +92,20 @@ def test_flags():
           gd.is_test_repo("MorphoDepotTesting/delete-22"))
     check("MorphoDepotTest/MRHead is a test repo", gd.is_test_repo("MorphoDepotTest/MRHead"))
     check("test- prefix anywhere is a test repo", gd.is_test_repo("someuser/test-foo-bar-5"))
+    # 'test'/'demo' as a whole word anywhere in the name (separator- or camelCase-delimited).
+    check("bare 'test' name is a test repo", gd.is_test_repo("leighamarielynch/test"))
+    check("underscore-delimited test is a test repo", gd.is_test_repo("Peter-T-Ruehr/MRI_test_head"))
+    check("trailing camelCase Test is a test repo", gd.is_test_repo("jknaub/Mako_Vert_MD_Test"))
+    check("glued camelCase Test is a test repo", gd.is_test_repo("CDonatelli/CDHumanTest"))
+    check("mid-name test word is a test repo",
+          gd.is_test_repo("otocolobusmanul3816/Copperhead_test_respository"))
+    check("leading Demo is a test repo", gd.is_test_repo("brendanlatham/Demo_HumanHead"))
+    check("mid-name demo word is a test repo", gd.is_test_repo("khurds137-beep/MRI_demo_for_workshop"))
     check("real species repo is not", not gd.is_test_repo("muratmaga/Gorilla_skull"))
     check("'Testudo' (no hyphen) is not a test repo", not gd.is_test_repo("x/Testudo_graveyard"))
+    check("'Testudo_graeca' tortoise is not a test repo", not gd.is_test_repo("x/Testudo_graeca"))
+    check("'Demospongiae' sponge is not a test repo", not gd.is_test_repo("x/Demospongiae_sample"))
+    check("'Demodex' mite is not a test repo", not gd.is_test_repo("x/Demodex_folliculorum"))
     check("MorphoDepot/member (org, real) is not a test repo",
           not gd.is_test_repo("MorphoDepot/member"))
     check("ephemeral from Short-term repoType",

--- a/scripts/test_duplicates.py
+++ b/scripts/test_duplicates.py
@@ -101,11 +101,23 @@ def test_flags():
           gd.is_test_repo("otocolobusmanul3816/Copperhead_test_respository"))
     check("leading Demo is a test repo", gd.is_test_repo("brendanlatham/Demo_HumanHead"))
     check("mid-name demo word is a test repo", gd.is_test_repo("khurds137-beep/MRI_demo_for_workshop"))
+    # sample / sicb / workshop / practice words (teaching + conference artifacts).
+    check("singular 'sample' is a test repo", gd.is_test_repo("ramenegaz/MRhead_sample"))
+    check("SICB conference repo is a test repo", gd.is_test_repo("kforsgren-1112013/KLF_SICB_2026"))
+    check("lowercase 'sicb2' token is a test repo", gd.is_test_repo("sunnyjsh/Sunny_sicb2"))
+    check("'workshop' is a test repo", gd.is_test_repo("kumimatsui/Dasyuridae_Workshop"))
+    check("'practice' is a test repo", gd.is_test_repo("annikadawley/SICB_Practice_Repository"))
+    # explicit one-off blocklist (no give-away word), case-insensitive on owner/name.
+    check("explicit EXCLUDED_REPOS entry is a test repo", gd.is_test_repo("amm554/non-member"))
+    check("EXCLUDED_REPOS match is case-insensitive", gd.is_test_repo("AMM554/Non-Member"))
     check("real species repo is not", not gd.is_test_repo("muratmaga/Gorilla_skull"))
     check("'Testudo' (no hyphen) is not a test repo", not gd.is_test_repo("x/Testudo_graveyard"))
     check("'Testudo_graeca' tortoise is not a test repo", not gd.is_test_repo("x/Testudo_graeca"))
-    check("'Demospongiae' sponge is not a test repo", not gd.is_test_repo("x/Demospongiae_sample"))
+    check("'Demospongiae' sponge is not a test repo", not gd.is_test_repo("x/Demospongiae_specimen"))
     check("'Demodex' mite is not a test repo", not gd.is_test_repo("x/Demodex_folliculorum"))
+    # plural 'samples' (a real museum-samples repo) must survive — only singular 'sample' is blocked.
+    check("plural 'Museum_samples' is NOT a test repo",
+          not gd.is_test_repo("skrobanm/Canis_lupus_Europe_Museum_samples"))
     check("MorphoDepot/member (org, real) is not a test repo",
           not gd.is_test_repo("MorphoDepot/member"))
     check("ephemeral from Short-term repoType",


### PR DESCRIPTION
## Problem
The RepoClerk dashboard carousel showcased throwaway **test / demo / conference / sample** repos alongside real datasets. The carousel was built from *every* repo (screenshot-bearing only) with no `isTest` filter, so any such repo that happened to have screenshots leaked into the public showcase (e.g. `MorphoDepotTest/MRHead`, `Peter-T-Ruehr/MRI_test_head`, `brendanlatham/Demo_HumanHead`, `khurds137-beep/MRI_demo_for_workshop`, `otocolobusmanul3816/Copperhead_test_respository`, `Jwyneken/SICB_sample`, `ramenegaz/MRhead_sample`, ...).

The existing detection (`is_test_repo`) only matched testing orgs and names starting with `test-`, so substring `test`, `demo`, and conference/sample names had `isTest:false` and slipped past even the table's "Hide test repositories" checkbox.

## Fix
1. **`generate-dashboard.py`** — `isTest` is now true when:
   - the owner is a known testing org (`MorphoDepotTesting` / `MorphoDepotTest`) — wholesale, name notwithstanding;
   - the `owner/name` is on an explicit one-off blocklist (`EXCLUDED_REPOS`, currently `amm554/non-member`); or
   - the **name contains the whole word** `test`, `demo`, `sample`, `sicb`, `workshop`, or `practice` (case-insensitive).

   Matching is word-aware (splits on separators **and** camelCase) so it catches `MRI_test_head`, `CDHumanTest`, `Mako_Vert_MD_Test`, `Demo_HumanHead`, `SICB_sample`, `KLF_SICB_2026`, `Dasyuridae_Workshop`, `MRhead_sample` — while leaving real taxa/collections untouched: `Testudo` (tortoise), `Demospongiae` (sponge), and the **plural** `Museum_samples` (only singular `sample` is blocked).
2. **`dashboard.js`** — carousel now filters `!isTest`. **Personal repos are still shown in the carousel** (only throwaways drop out); the default table view is unchanged.
3. **`index.html`** — filter label updated to "Hide test/demo repositories" to match the expanded scope.

Regenerated `dashboard-data.json` + `volume-checksums.json`.

## Result
Every flagged repo is now excluded from the showcase — including `amm554/non-member` (explicit blocklist) and `ramenegaz/MRhead_sample` (singular `sample`). The rule generalises to sibling conference/workshop repos (`Bennington_SICB2026_MRIHead`, `natasha_sicb_2026`, `SICB_Practice_Repository`, `Dasyuridae_Workshop`). The carousel keeps all real personal + org datasets.

## Tests
`test_duplicates.py::test_flags` extended with the new word-match cases, the explicit-blocklist/case-insensitive cases, and false-positive guards (`Testudo_graeca`, `Demospongiae`, `Demodex`, plural `Museum_samples`). All pass:
```
python3 scripts/test_duplicates.py  # All duplicate-report tests passed.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
