### PR TITLE
Guard generated dashboard files from PR commits

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Generated dashboard artifacts — written only by the Sync workflow on main (see README
+# "Development"). Marked generated so GitHub collapses their diffs and excludes them from language
+# stats; do not hand-edit or commit them in a PR.
+docs/dashboard-data.json linguist-generated=true
+docs/volume-checksums.json linguist-generated=true

--- a/.github/workflows/guard-generated.yml
+++ b/.github/workflows/guard-generated.yml
@@ -35,7 +35,7 @@ jobs:
             docs/dashboard-data.json docs/volume-checksums.json)"
           if [ -n "$changed" ]; then
             echo "::error::These files are generated on main by the Sync workflow and must not be committed in a PR:"
-            printf '  %s\n' $changed
+            printf '%s\n' "$changed" | sed 's/^/  /'
             echo "Fix: git checkout origin/main -- docs/dashboard-data.json docs/volume-checksums.json"
             echo "then commit and push. The Sync workflow regenerates them on main after your PR merges."
             exit 1

--- a/.github/workflows/guard-generated.yml
+++ b/.github/workflows/guard-generated.yml
@@ -1,0 +1,43 @@
+name: Guard generated files
+
+# The dashboard artifacts docs/dashboard-data.json and docs/volume-checksums.json are written ONLY
+# by the Sync/ingestion workflows (sync-all.yml, update-repo.yml) running generate-dashboard.py on
+# main. They must stay committed on main because GitHub Pages serves docs/ straight from main, but a
+# feature branch must never commit them: they change on essentially every journal update, so a PR
+# that also edits them merge-conflicts with the Sync bot. A conflicting PR cannot build its
+# refs/pull/<n>/merge ref, which silently stops GitHub from running Claude Code Review (or any other
+# pull_request workflow) on it. This guard fails fast so the mistake is caught while the PR is still
+# mergeable, instead of the review just never appearing. See README "Development".
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Reject changes to generated dashboard files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Compare from the divergence point (merge-base), so a base branch that has simply moved
+          # ahead does not look like a change made by this PR.
+          base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+          changed="$(git diff --name-only "$base" "$HEAD_SHA" -- \
+            docs/dashboard-data.json docs/volume-checksums.json)"
+          if [ -n "$changed" ]; then
+            echo "::error::These files are generated on main by the Sync workflow and must not be committed in a PR:"
+            printf '  %s\n' $changed
+            echo "Fix: git checkout origin/main -- docs/dashboard-data.json docs/volume-checksums.json"
+            echo "then commit and push. The Sync workflow regenerates them on main after your PR merges."
+            exit 1
+          fi
+          echo "OK — no generated dashboard files modified by this PR."

--- a/README.md
+++ b/README.md
@@ -205,3 +205,28 @@ accepts `repository_dispatch` (it does). To (re)provision the webhook:
 - **`pushedAt` preserved** from GitHub so the cron job can detect staleness without fetching full issue/PR data for every repo on every run
 - **Webhook-driven, cron as safety net** — the primary update path is the org webhook → on-demand `repository_dispatch` (push, not poll; ~20 s to a fresh journal); the hourly cron catches any missed delivery and handles initial population. See [`design/near-realtime-ingestion.md`](design/near-realtime-ingestion.md) and *How Journals Get Updated* above
 - **`viewerPermission` is NOT in the journal** — this is viewer-specific and cannot be pre-computed; `administratedRepoList()` in MorphoDepot still needs a direct `gh` API call
+
+## Development
+
+`docs/dashboard-data.json` and `docs/volume-checksums.json` are **generated artifacts**. They are
+written only by the Sync/ingestion workflows (`sync-all.yml`, `update-repo.yml`) running
+`scripts/generate-dashboard.py` on `main`, and they stay committed there because GitHub Pages serves
+`docs/` straight from `main`.
+
+**Do not commit changes to these two files in a pull request.** They are rewritten on `main` on
+essentially every journal update, so any PR that also edits them merge-conflicts with the Sync bot. A
+conflicting PR cannot build its `refs/pull/<n>/merge` ref, which silently stops GitHub from running
+the Claude Code Review (and every other `pull_request` workflow) on it — the review simply never
+appears. The `Guard generated files` workflow enforces this by failing any PR that touches them.
+
+When you change dashboard logic (`generate-dashboard.py`, `dashboard.js`, `index.html`), run
+`python3 scripts/generate-dashboard.py` locally only to preview, then drop the generated files before
+pushing:
+
+```sh
+git checkout origin/main -- docs/dashboard-data.json docs/volume-checksums.json
+```
+
+After the PR merges, the next Sync run (hourly cron, or ~20 s via the webhook) regenerates them on
+`main` with your new logic. Run the unit tests with `python3 scripts/test_duplicates.py` (no deps, no
+network).


### PR DESCRIPTION
## Why
`docs/dashboard-data.json` and `docs/volume-checksums.json` are **generated** by the Sync workflows (`generate-dashboard.py`) on `main`. They stay committed on `main` because GitHub Pages serves `docs/` from `main` (legacy Pages, `main:/docs`).

The problem: when a feature branch *also* commits them, it merge-conflicts with the Sync bot — which rewrites them on essentially every journal update. **A conflicting PR cannot build its `refs/pull/<n>/merge` ref, so GitHub silently never runs `Claude Code Review` (or any `pull_request` workflow) on it.** That is exactly what stalled PR #438's review for ~11 days-of-my-confusion earlier today: no run, no error, just a permanently-`pending` status.

## What
- **`.github/workflows/guard-generated.yml`** — a `pull_request` job that fails if the PR diff (vs merge-base) touches either generated file. It catches the mistake *while the PR is still mergeable*, before the Sync bot turns it into an invisible-review conflict. (It runs green on this very PR, which touches neither file.)
- **`.gitattributes`** — marks both files `linguist-generated` so GitHub collapses their diffs and drops them from language stats.
- **README `## Development`** — documents why they must not be committed and how to drop them before pushing:
  ```sh
  git checkout origin/main -- docs/dashboard-data.json docs/volume-checksums.json
  ```
  Sync regenerates them on `main` (hourly cron, or ~20 s via webhook) after merge.

## Not changed
The files stay tracked on `main` (Pages needs them); only the Sync workflows write them. This is a policy/guard change, not a data change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)