### PR TITLE
Drop track_progress: it silently discards the analysis on issues

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -58,7 +58,9 @@ jobs:
         uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Not in the extension's copy, but matches claude-code-review.yml in this repo:
-          # posts a live-updating comment instead of going quiet until the run finishes.
-          # Worth more here than there, since issue replies are the interactive path.
-          track_progress: true
+          # Do NOT set track_progress here. It works in claude-code-review.yml because a PR
+          # has a branch to diff, but on an issue there is nothing to compare: the action's
+          # post-step calls the compare-two-commits API, 404s, and never writes the final
+          # body — leaving the progress checklist with every box unticked and the analysis
+          # discarded. Observed on run 31213175637 (#469): the run itself succeeded, 9 turns,
+          # is_error false, and the output was lost anyway. The extension's copy omits it too.


### PR DESCRIPTION
Follow-up to #471, fixing a regression that PR introduced.

`track_progress: true` was added there on review advice — the reasoning being that it matches `claude-code-review.yml` in this repo and gives a live-updating comment instead of silence. That reasoning was wrong, and I accepted it without testing.

The two workflows run in different contexts. On a **pull request** the action has a branch to diff, so its post-step works. On an **issue** there is no branch, so the post-step's `compare-two-commits` call 404s and the final comment body is never written.

The failure mode is the worst kind: silent and total.

```
Error checking for changes in branch: HttpError: Not Found
  - https://docs.github.com/rest/commits/commits#compare-two-commits
```

Run [31213175637](https://github.com/MorphoDepot/RepoClerk/actions/runs/31213175637) on #469 completed successfully — `"subtype": "success"`, `"is_error": false`, 9 turns, $0.55 — and posted nothing but the progress checklist with every box still unticked. The analysis was not in the job log either, so it is simply gone; the question has to be asked again.

The extension's copy of this file has never set `track_progress`, and its issue replies post complete analyses (see SlicerMorph/SlicerMorphoDepot#211 and #212, both fine). That is the working reference, and this returns to it.

I left a comment in place explaining why rather than just deleting the line, since "this repo's other workflow sets it" is a genuinely reasonable thing to notice, and the next person to notice it deserves the counter-argument rather than repeating the experiment.

## Verification after merge

Re-ask the #469 question and confirm a complete reply posts. That question — whether dropping the label gate makes the drain loop spin until timeout — is currently unanswered because of this bug.