### PR TITLE
Detect issue and PR activity with a watermark, not Repository.updatedAt

### DIFF
--- a/design/near-realtime-ingestion.md
+++ b/design/near-realtime-ingestion.md
@@ -148,20 +148,55 @@ Four layers, ordered so that each is useful alone and none depends on the next.
 
 ### Layer 1 — Make the pull path authoritative (the correctness floor)
 
-Fix [#470](https://github.com/MorphoDepot/RepoClerk/issues/470): compare repo `updatedAt` alongside
-`pushedAt`. `updatedAt` moves on issue create, assignment, retitle, close, and PR events; an
-open-issue `totalCount` would miss "one closed, one opened in the same window".
+Fix [#470](https://github.com/MorphoDepot/RepoClerk/issues/470): give the sweep a change token that
+actually moves when issues and pull requests move.
 
-This is **6 edits across 2 files plus a shared constant**, not the one-liner it looks like:
+**Not `Repository.updatedAt`.** An earlier draft of this section proposed exactly that, and it is
+wrong — `updatedAt` tracks the repository *record* (description, topics, visibility), not its issues.
+Measured against live repos on 2026-08-07, before writing any code:
+
+| repo | `updatedAt` | newest issue |
+|---|---|---|
+| `jaimigray/snakeseg` | 2025-10-07T16:46:18Z | 2026-07-07T11:39:01Z |
+| `dinonoto/Juvenile_Bearded_Dragon` | 2026-06-09T19:01:40Z | 2026-06-11T12:55:30Z |
+| `muratmaga/rana-clamitans-full-body` | 2026-08-07T18:28:07Z | 2026-08-07T18:30:05Z |
+
+`snakeseg` had nine months of issue activity that never touched `updatedAt`. Comparing it would have
+shipped a fix that changed nothing, and the tests would have passed, because the assumption was in
+the fixture as much as the code.
+
+The token that does work is an **activity watermark**: the newest issue-or-PR update time, from
+`issues(first: 1, orderBy: {field: UPDATED_AT, direction: DESC})` and the same for
+`pullRequests`. Deliberately unfiltered by state — closing an issue must move the watermark forward,
+whereas a `states: OPEN` filter would make it jump *backwards* to the next-newest open item. It is
+strictly better than an open-issue `totalCount`, which cannot see a reassignment or a
+close-one-open-one within the same window.
+
+Cost, measured on the whole 80-repo fleet: **2 GraphQL points** against a 5,000/hour budget, in the
+discovery search that already runs. The `first: 1` is what keeps it that cheap — the same search
+pulling 100 issues and 100 PRs per repo costs 202.
+
+Three tokens are journaled, none redundant:
+
+| token | moves on |
+|---|---|
+| `pushedAt` | git pushes — gates the expensive artifact re-fetch (accession, captions, volume HEAD) |
+| `updatedAt` | the repository record — a collection's title is its description, so this still matters |
+| `activityAt` | newest issue or PR update — the one that fixes the reported bug |
 
 | file | change |
 |---|---|
-| `sync-all.py` | GraphQL fragment; JQ filter (the return shape changes from `{nwo: pushedAt}` to `{nwo: {pushedAt, updatedAt}}`); the journal read; the staleness comparison |
-| `drain.py` | `GRAPHQL_QUERY` gains `updatedAt`; `process_repo()` writes it |
-| `constants.py` *(new)* | `SCHEMA_VERSION`, imported by both — `sync-all.py:21` is `2` while `drain.py:29` is `3`, so the schema-upgrade backfill is currently dead. Do **not** import it from `drain`: `drain.py` ends in a bare `main()` with no `__main__` guard, so importing it would run the drain loop as a side effect. |
+| `sync-all.py` | search query and JQ filter gain the three tokens; `staleness_reason()` extracted as a pure function and extended; the journal read |
+| `drain.py` | `GRAPHQL_QUERY` gains `updatedAt` and the two aliased `first: 1` connections; new `activity_watermark()`; `process_repo()` writes both fields |
+| `constants.py` *(new)* | `SCHEMA_VERSION`, imported by both — it was `2` in `sync-all.py` and `3` in `drain.py`, which silently disabled the schema-upgrade backfill entirely |
+| `test_staleness.py` *(new)* | covers each token, the pre-upgrade path, and a regression test that fails if anyone swaps the watermark back for `updatedAt` |
 
-Adding a journal field is a schema change, so `SCHEMA_VERSION` goes to 4 and every journal is
-re-queued once. That is desirable — it clears the accumulated staleness in the same pass.
+Both scripts also gained `if __name__ == "__main__"` guards, without which the logic cannot be
+imported by a test at all.
+
+Adding journal fields is a schema change, so `SCHEMA_VERSION` goes to 4 and every journal is
+re-queued once. That is desirable — it clears the accumulated staleness in the same pass, and it is
+what stops a journal with no `activityAt` from being reported stale on every sweep forever.
 
 **Why this first:** it is the only layer that makes correctness independent of who the actor is, what
 permissions they hold, and which tier the repo lives in. It also happens to be the only fix for the
@@ -216,7 +251,7 @@ passed.
 - An open, unlabeled `update ...` issue older than a few minutes is a known-bad state and should
   alarm.
 - Dispatch and drain *failures* should alarm. Ten silent failures in 31 runs is the current baseline.
-- **Publish a freshness metric**: max and median `now - journalUpdatedAt` against repo `updatedAt`,
+- **Publish a freshness metric**: max and median `now - journalUpdatedAt` against `activityAt`,
   on the dashboard. One number that would have made all of this obvious on day one.
 
 ### Layer 4 — Make it affordable at 5–10× the current size
@@ -236,7 +271,7 @@ size.
 HEAD against the volume URL — an S3 redirect chain on a multi-GB object — and runs all of them on
 every refresh, including one triggered by a single issue comment. Split the two signals by cost:
 **`pushedAt` gates the expensive artifact fetches** (accession, captions, `CURATOR`, checksum, volume
-HEAD — none of which can change without a push), **`updatedAt` gates a cheap issues/PRs-only
+HEAD — none of which can change without a push), **`activityAt` gates a cheap issues/PRs-only
 refresh**. Then batch that cheap refresh with GraphQL aliases (`r0: repository(...) r1: ...`), so 500
 repos cost ~10 requests rather than 500. Verify node-count and complexity limits before fixing a
 batch size.

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -20,5 +20,7 @@ puts `scripts/` on sys.path[0], so a plain `import constants` resolves.
 # every existing journal for a one-time backfill.
 #   v2 added sourceVolumeChecksum
 #   v3 added curator / collection
-#   v4 added updatedAt (repo-level change token; see design/near-realtime-ingestion.md)
+#   v4 added updatedAt (repository-record change token) and activityAt (newest issue-or-PR
+#      update time -- the signal Repository.updatedAt looks like it provides and does not;
+#      see design/near-realtime-ingestion.md and #470)
 SCHEMA_VERSION = 4

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -1,0 +1,24 @@
+"""Constants shared by drain.py and sync-all.py.
+
+This module exists so the two scripts cannot drift apart again: SCHEMA_VERSION was
+2 in sync-all.py while drain.py emitted 3, which silently disabled the whole
+schema-upgrade backfill path (sync-all would never flag a v3 journal as needing
+a rewrite, because it believed 2 was current).
+
+It is a separate module rather than the constant living in one script and being
+imported by the other: a script is an entry point, not a library, and importing
+one to reach a constant couples the two in the wrong direction.  (Until this
+change both scripts also ended in a bare `main()` call, so importing either would
+have run it as a side effect.  Both now carry `if __name__ == "__main__"` guards,
+which is what makes staleness_reason() testable.)
+
+Both scripts are invoked as `python3 scripts/<name>.py` from the repo root, which
+puts `scripts/` on sys.path[0], so a plain `import constants` resolves.
+"""
+
+# Journal schema version. Bump when the journal shape changes so sync-all re-queues
+# every existing journal for a one-time backfill.
+#   v2 added sourceVolumeChecksum
+#   v3 added curator / collection
+#   v4 added updatedAt (repo-level change token; see design/near-realtime-ingestion.md)
+SCHEMA_VERSION = 4

--- a/scripts/drain.py
+++ b/scripts/drain.py
@@ -20,18 +20,37 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+# Running as `python3 scripts/drain.py` already puts scripts/ on sys.path, but loading
+# this file by path (as the test_*.py helpers do) does not. Make the import work either way.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from constants import SCHEMA_VERSION
+
 GITHUB_REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "")
 MAX_IDLE_CYCLES = 3
 POLL_INTERVAL = 5  # seconds
 
-# Journal schema version. Bump when the journal shape changes so sync-all re-queues
-# existing journals for a one-time backfill. v2 added sourceVolumeChecksum.
-SCHEMA_VERSION = 3
+# Three change tokens, because no single GitHub field covers everything sync-all must notice:
+#   pushedAt   -- git pushes only
+#   updatedAt  -- the repository *record* (description, topics, visibility). Notably this does
+#                 NOT move on issue or pull-request activity; see ACTIVITY_FIELDS below.
+#   latestIssue / latestPR -- the newest issue and PR by update time, which is the only cheap
+#                 signal that does track issue and PR activity. Aliased because the same fields
+#                 are queried again below with different arguments.
+ACTIVITY_FIELDS = """
+    latestIssue: issues(first: 1, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      nodes { updatedAt }
+    }
+    latestPR: pullRequests(first: 1, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      nodes { updatedAt }
+    }
+"""
 
 GRAPHQL_QUERY = """
 query($owner: String!, $repo: String!) {
   repository(owner: $owner, name: $repo) {
     pushedAt
+    updatedAt
+""" + ACTIVITY_FIELDS + """
     description
     repositoryTopics(first: 30) { nodes { topic { name } } }
     issues(states: OPEN, first: 100) {
@@ -129,6 +148,25 @@ def parse_collection_readme(text, self_nwo):
         description += (" " if description else "") + s
 
     return {"title": title, "description": description, "memberRefs": refs}
+
+
+def activity_watermark(repo_data):
+    """Newest issue-or-PR update time for a repo, as an ISO-8601 string ("" if it has none).
+
+    This is the change token for issue and pull-request activity.  It exists because
+    Repository.updatedAt does *not* move on that activity -- it tracks the repository
+    record.  Measured on live repos 2026-08-07: jaimigray/snakeseg had issue activity on
+    2026-07-07 and an updatedAt of 2025-10-07, nine months behind.
+
+    No state filter, deliberately: closing an issue must move the watermark forward, and
+    filtering to OPEN would instead make it jump *backwards* to the next-newest open item.
+
+    ISO-8601 UTC strings sort correctly as plain strings, so max() is the whole comparison.
+    """
+    def newest(key):
+        nodes = ((repo_data.get(key) or {}).get("nodes") or [])
+        return nodes[0]["updatedAt"] if nodes else ""
+    return max(newest("latestIssue"), newest("latestPR"))
 
 
 def resolve_volume_url(volume_ref, name_with_owner):
@@ -251,6 +289,8 @@ def process_repo(owner, repo):
         "nameWithOwner": f"{owner}/{repo}",
         "journalUpdatedAt": now,
         "pushedAt": data["pushedAt"],
+        "updatedAt": data["updatedAt"],
+        "activityAt": activity_watermark(data),
         "openIssues": open_issues,
         "openPRs": open_prs,
         "accession": accession,
@@ -373,4 +413,5 @@ def main():
         sys.exit(1)
 
 
-main()
+if __name__ == "__main__":
+    main()

--- a/scripts/drain.py
+++ b/scripts/drain.py
@@ -165,7 +165,9 @@ def activity_watermark(repo_data):
     """
     def newest(key):
         nodes = ((repo_data.get(key) or {}).get("nodes") or [])
-        return nodes[0]["updatedAt"] if nodes else ""
+        # updatedAt is DateTime! in GitHub's schema so it cannot be null, but keep the
+        # "always returns a string" contract self-enforcing: max(None, str) raises.
+        return (nodes[0].get("updatedAt") or "") if nodes else ""
     return max(newest("latestIssue"), newest("latestPR"))
 
 

--- a/scripts/sync-all.py
+++ b/scripts/sync-all.py
@@ -14,11 +14,12 @@ import subprocess
 import sys
 from pathlib import Path
 
-GITHUB_REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "")
+# Running as `python3 scripts/sync-all.py` already puts scripts/ on sys.path, but loading
+# this file by path (as test_staleness.py does) does not. Make the import work either way.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from constants import SCHEMA_VERSION
 
-# Keep in sync with drain.SCHEMA_VERSION. A journal whose schemaVersion is below this
-# is treated as stale, so a schema bump backfills every journal on the next sync.
-SCHEMA_VERSION = 2
+GITHUB_REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "")
 
 
 def run(cmd, check=True):
@@ -26,11 +27,25 @@ def run(cmd, check=True):
 
 
 def search_topic(topic):
-    """Return {nameWithOwner: pushedAt} for live repos carrying `topic` (forks included)."""
+    """Return {nameWithOwner: {pushedAt, updatedAt, activityAt}} for repos carrying `topic`.
+
+    All three change tokens come back in the one discovery search that was happening
+    anyway.  Measured cost for the whole 80-repo fleet: 2 GraphQL points, against a
+    5,000/hour budget -- the two `first: 1` connections are what keep it that cheap.
+
+    They cover different things and none is redundant:
+      pushedAt   git pushes
+      updatedAt  the repository record -- description (a collection's title comes from
+                 it), topics, visibility
+      activityAt newest issue-or-PR update, the only cheap signal that tracks issue and
+                 pull-request activity, which updatedAt does not (see drain.activity_watermark)
+    """
     result = run([
         "gh", "api", "graphql",
         "--paginate",
-        "--jq", ".data.search.nodes[] | {nameWithOwner, pushedAt}",
+        "--jq", ".data.search.nodes[] | {nameWithOwner, pushedAt, updatedAt, "
+                "latestIssue: (.latestIssue.nodes[0].updatedAt // \"\"), "
+                "latestPR: (.latestPR.nodes[0].updatedAt // \"\")}",
         "-f", f"""query=
           query($cursor: String) {{
             search(
@@ -41,7 +56,15 @@ def search_topic(topic):
             ) {{
               pageInfo {{ hasNextPage endCursor }}
               nodes {{
-                ... on Repository {{ nameWithOwner pushedAt }}
+                ... on Repository {{
+                  nameWithOwner pushedAt updatedAt
+                  latestIssue: issues(first: 1, orderBy: {{field: UPDATED_AT, direction: DESC}}) {{
+                    nodes {{ updatedAt }}
+                  }}
+                  latestPR: pullRequests(first: 1, orderBy: {{field: UPDATED_AT, direction: DESC}}) {{
+                    nodes {{ updatedAt }}
+                  }}
+                }}
               }}
             }}
           }}
@@ -52,8 +75,48 @@ def search_topic(topic):
         line = line.strip()
         if line:
             entry = json.loads(line)
-            repos[entry["nameWithOwner"]] = entry.get("pushedAt", "")
+            repos[entry["nameWithOwner"]] = {
+                "pushedAt": entry.get("pushedAt", ""),
+                "updatedAt": entry.get("updatedAt", ""),
+                # Same max() as drain.activity_watermark, so the two are comparable.
+                "activityAt": max(entry.get("latestIssue") or "",
+                                  entry.get("latestPR") or ""),
+            }
     return repos
+
+
+def staleness_reason(journal, remote):
+    """Why `remote` needs re-draining, or None if the journal is current.
+
+    `journal` is the local record (or None if there is no journal file); `remote` is
+    {pushedAt, updatedAt} from the topic search.  Pure and side-effect free so it can
+    be tested without network -- see test_staleness.py.
+
+    Order matters only for the label the digest prints; any of these firing re-drains.
+    pushedAt is checked first because it is the strongest signal -- new content means the
+    expensive artifacts genuinely changed.
+
+    activityAt is the one that fixes #470.  It is the newest issue-or-PR update time,
+    because *neither* pushedAt nor updatedAt moves on issue and pull-request activity:
+    pushedAt tracks git pushes, updatedAt tracks the repository record.  That was verified
+    the hard way -- an earlier version of this fix compared updatedAt and would have
+    changed nothing at all.
+
+    A journal written before this field existed has no activityAt.  Comparing "" against a
+    real timestamp would report every repo stale on every sweep forever, so those fall
+    through to the schemaVersion check, which re-drains each exactly once and writes it.
+    """
+    if journal is None:
+        return "missing"
+    if journal.get("pushedAt", "") != remote["pushedAt"]:
+        return "stale"
+    if journal.get("updatedAt") and journal["updatedAt"] != remote["updatedAt"]:
+        return "metadata"
+    if journal.get("activityAt") and journal["activityAt"] != remote["activityAt"]:
+        return "activity"
+    if journal.get("schemaVersion", 1) < SCHEMA_VERSION:
+        return "schema-upgrade"
+    return None
 
 
 def main():
@@ -79,24 +142,19 @@ def main():
             with open(path) as f:
                 data = json.load(f)
             journaled_repos[nwo] = {"path": path, "pushedAt": data.get("pushedAt", ""),
+                                    "updatedAt": data.get("updatedAt", ""),
+                                    "activityAt": data.get("activityAt", ""),
                                     "schemaVersion": data.get("schemaVersion", 1)}
         except Exception:
-            journaled_repos[nwo] = {"path": path, "pushedAt": "", "schemaVersion": 0}
+            journaled_repos[nwo] = {"path": path, "pushedAt": "", "updatedAt": "",
+                                    "activityAt": "", "schemaVersion": 0}
 
     print(f"Found {len(journaled_repos)} existing journal file(s)")
 
     # 3. Create update-request issues for missing or stale repos
     issues_created = 0
-    for nwo, remote_pushed_at in live_repos.items():
-        journal = journaled_repos.get(nwo)
-        if journal is None:
-            reason = "missing"
-        elif journal["pushedAt"] != remote_pushed_at:
-            reason = "stale"
-        elif journal.get("schemaVersion", 1) < SCHEMA_VERSION:
-            reason = "schema-upgrade"
-        else:
-            reason = None
+    for nwo, remote in live_repos.items():
+        reason = staleness_reason(journaled_repos.get(nwo), remote)
 
         if reason:
             r = run([
@@ -147,4 +205,5 @@ def main():
         print(f"Deleted {len(deleted)} stale journal(s)")
 
 
-main()
+if __name__ == "__main__":
+    main()

--- a/scripts/test_collections.py
+++ b/scripts/test_collections.py
@@ -5,21 +5,24 @@ generate-dashboard.build_collections.
 Run: python3 scripts/test_collections.py   (no deps, no network)
 """
 import importlib.util
-import re
 from pathlib import Path
 
-# generate-dashboard.py has a __main__ guard, so importlib-load it directly.
-_spec = importlib.util.spec_from_file_location(
-    "gen_dashboard", Path(__file__).with_name("generate-dashboard.py"))
-gd = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(gd)
 
-# drain.py ends with a bare main() call, so load it with that call stripped (no network run).
-_drain_src = Path(__file__).with_name("drain.py").read_text()
-_drain_src = re.sub(r'^main\(\)\s*$', '', _drain_src, flags=re.M)
-_drain_ns = {}
-exec(compile(_drain_src, "drain.py", "exec"), _drain_ns)
-parse_collection_readme = _drain_ns["parse_collection_readme"]
+def _load(filename, name):
+    spec = importlib.util.spec_from_file_location(name, Path(__file__).with_name(filename))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+gd = _load("generate-dashboard.py", "gen_dashboard")
+
+# drain.py used to end in a bare main() call, so this loaded it by regex-stripping that
+# line before exec()ing the source. It now has a __main__ guard and can be imported like
+# any other module -- which also gives it a real __file__, without which its own imports
+# cannot resolve.
+drain = _load("drain.py", "drain")
+parse_collection_readme = drain.parse_collection_readme
 
 
 def check(name, cond):

--- a/scripts/test_staleness.py
+++ b/scripts/test_staleness.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Unit tests for sync-all.py's staleness_reason() and drain.py's activity_watermark().
+
+Run: python3 scripts/test_staleness.py   (no deps, no network)
+
+The bug these guard against (#470): the staleness test used to compare only pushedAt,
+which moves on a git push and nothing else.  Opening, assigning, or closing an issue does
+not move it, and a fork's pull request does not move the *upstream* repo's.  So once a
+journal was written with a current pushedAt, every issue and PR event afterwards was
+invisible to the hourly sweep -- permanently, not for an hour.
+
+The trap these also guard against: Repository.updatedAt looks like the obvious fix and is
+not.  It tracks the repository *record*, not its issues.  Measured on live repos
+2026-08-07:
+
+    repo                              updatedAt             newest issue
+    jaimigray/snakeseg                2025-10-07T16:46:18Z  2026-07-07T11:39:01Z
+    dinonoto/Juvenile_Bearded_Dragon  2026-06-09T19:01:40Z  2026-06-11T12:55:30Z
+    muratmaga/rana-clamitans...       2026-08-07T18:28:07Z  2026-08-07T18:30:05Z
+
+snakeseg's updatedAt was nine months behind its issue activity.  Comparing it would have
+shipped a fix that changed nothing.  See design/near-realtime-ingestion.md.
+"""
+import importlib.util
+from pathlib import Path
+
+
+def _load(filename, name):
+    spec = importlib.util.spec_from_file_location(name, Path(__file__).with_name(filename))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+sync_all = _load("sync-all.py", "sync_all")
+drain = _load("drain.py", "drain")
+
+CURRENT = sync_all.SCHEMA_VERSION
+PUSH = "2026-08-07T18:22:43Z"
+META = "2026-08-07T18:28:07Z"
+SEEN = "2026-08-07T18:28:30Z"
+LATER = "2026-08-07T18:30:05Z"
+
+
+def journal(pushed=PUSH, updated=META, activity=SEEN, schema=CURRENT):
+    return {"pushedAt": pushed, "updatedAt": updated, "activityAt": activity,
+            "schemaVersion": schema}
+
+
+def remote(pushed=PUSH, updated=META, activity=SEEN):
+    return {"pushedAt": pushed, "updatedAt": updated, "activityAt": activity}
+
+
+def check(name, cond):
+    print(f"  {'PASS' if cond else 'FAIL'}  {name}")
+    assert cond, name
+
+
+def test_current_journal_is_left_alone():
+    check("a journal matching on all three tokens is not re-queued",
+          sync_all.staleness_reason(journal(), remote()) is None)
+
+
+def test_missing_journal():
+    check("no journal file at all -> missing",
+          sync_all.staleness_reason(None, remote()) == "missing")
+
+
+def test_push_still_detected():
+    check("a new push -> stale",
+          sync_all.staleness_reason(journal(), remote(pushed=LATER)) == "stale")
+
+
+def test_issue_activity_without_a_push():
+    """The regression that caused the 2026-08-07 classroom outage.
+
+    Five issues were created on a repo 18 seconds after its journal was written.  No push
+    accompanied them, so pushedAt was unchanged and the sweep saw nothing to do.
+    """
+    check("issue activity with no push -> activity (was: ignored forever)",
+          sync_all.staleness_reason(journal(), remote(activity=LATER)) == "activity")
+
+
+def test_fork_pr_does_not_need_a_push():
+    # A fork's PR leaves the upstream pushedAt untouched but does move the newest-PR
+    # watermark, so it reaches the journal by the same route as an issue.
+    check("a fork's pull request -> activity",
+          sync_all.staleness_reason(journal(), remote(activity=LATER)) == "activity")
+
+
+def test_repo_updated_at_alone_would_have_missed_it():
+    """Documents why activityAt exists and updatedAt is not a substitute.
+
+    This is the live snakeseg shape: the repository record has not been touched in months
+    while issues kept moving.  If staleness keyed on updatedAt, this returns None and the
+    journal never refreshes.
+    """
+    stale_meta = journal(updated="2025-10-07T16:46:18Z", activity="2026-06-01T00:00:00Z")
+    live = remote(updated="2025-10-07T16:46:18Z", activity="2026-07-07T11:39:01Z")
+    check("issue activity while updatedAt sits still -> still caught",
+          sync_all.staleness_reason(stale_meta, live) == "activity")
+
+
+def test_repo_metadata_change():
+    # A collection's title comes from the repo description, so a record change must
+    # re-drain even with no push and no issue activity.
+    check("description or topic change -> metadata",
+          sync_all.staleness_reason(journal(), remote(updated=LATER)) == "metadata")
+
+
+def test_pre_upgrade_journal_upgrades_once_not_forever():
+    """A journal written before activityAt existed must not be reported stale forever.
+
+    Comparing "" against a live timestamp would match on every sweep, re-queueing the
+    whole fleet hourly for good.  Empty values fall through to the schema check, which
+    re-drains each repo exactly once and writes the field.
+    """
+    old = journal(updated="", activity="", schema=CURRENT - 1)
+    check("pre-upgrade journal -> schema-upgrade, not activity",
+          sync_all.staleness_reason(old, remote(activity=LATER)) == "schema-upgrade")
+    check("after the upgrade drain it is quiet again",
+          sync_all.staleness_reason(journal(activity=LATER), remote(activity=LATER)) is None)
+
+
+def test_pushed_at_takes_precedence():
+    # Everything moved: report the strongest signal, since a push means the expensive
+    # artifacts (accession, captions, volume size) genuinely need re-fetching.
+    check("all tokens moved -> stale",
+          sync_all.staleness_reason(journal(), remote(pushed=LATER, updated=LATER,
+                                                      activity=LATER)) == "stale")
+
+
+def test_unreadable_journal_is_re_queued():
+    # main() represents an unparseable journal file as empty strings + schemaVersion 0.
+    check("corrupt journal record -> re-queued rather than skipped",
+          sync_all.staleness_reason(
+              {"pushedAt": "", "updatedAt": "", "activityAt": "", "schemaVersion": 0},
+              remote()) == "stale")
+
+
+def test_watermark_matches_between_the_two_scripts():
+    """drain writes the watermark, sync-all reads it -- they must compute it identically."""
+    data = {"latestIssue": {"nodes": [{"updatedAt": SEEN}]},
+            "latestPR": {"nodes": [{"updatedAt": LATER}]}}
+    check("watermark is the newer of the two", drain.activity_watermark(data) == LATER)
+
+    check("PR newer than issue is handled either way round",
+          drain.activity_watermark({"latestIssue": {"nodes": [{"updatedAt": LATER}]},
+                                    "latestPR": {"nodes": [{"updatedAt": SEEN}]}}) == LATER)
+
+    check("a repo with no issues and no PRs -> empty, never None",
+          drain.activity_watermark({"latestIssue": {"nodes": []},
+                                    "latestPR": {"nodes": []}}) == "")
+
+    check("missing keys entirely -> empty",
+          drain.activity_watermark({}) == "")
+
+    # sync-all builds the same value from its own query shape; a divergence here would
+    # make every repo look permanently stale.
+    check("a fresh repo with neither is quiet, not permanently stale",
+          sync_all.staleness_reason(journal(activity=""), remote(activity="")) is None)
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            print(name)
+            fn()
+    print("\nall staleness tests passed")

--- a/scripts/test_staleness.py
+++ b/scripts/test_staleness.py
@@ -155,6 +155,12 @@ def test_watermark_matches_between_the_two_scripts():
     check("missing keys entirely -> empty",
           drain.activity_watermark({}) == "")
 
+    # updatedAt is DateTime! so a null cannot arrive from the API, but the function must
+    # still return a string rather than raising inside max().
+    check("a null timestamp degrades to empty instead of raising",
+          drain.activity_watermark({"latestIssue": {"nodes": [{"updatedAt": None}]},
+                                    "latestPR": {"nodes": [{"updatedAt": SEEN}]}}) == SEEN)
+
     # sync-all builds the same value from its own query shape; a divergence here would
     # make every repo look permanently stale.
     check("a fresh repo with neither is quiet, not permanently stale",


### PR DESCRIPTION
Fixes #470 — Layer 1 of `design/near-realtime-ingestion.md`, the correctness floor.

## The fix we almost shipped

The plan agreed in #470, and confirmed by two rounds of review, was to compare `Repository.updatedAt` alongside `pushedAt`. **That does not work.** `updatedAt` tracks the repository *record* — description, topics, visibility — not its issues.

Measured against live repos before writing any code:

| repo | `updatedAt` | newest issue |
|---|---|---|
| `jaimigray/snakeseg` | 2025-10-07T16:46:18Z | 2026-07-07T11:39:01Z |
| `dinonoto/Juvenile_Bearded_Dragon` | 2026-06-09T19:01:40Z | 2026-06-11T12:55:30Z |
| `muratmaga/rana-clamitans-full-body` | 2026-08-07T18:28:07Z | 2026-08-07T18:30:05Z |

`snakeseg` has had nine months of issue activity that never moved `updatedAt`. Shipping that version would have closed this issue, passed its tests, and changed nothing — the assumption would have been in the fixtures as much as in the code.

## What actually works

An **activity watermark**: the newest issue-or-PR update time, from `first: 1` connections ordered by `UPDATED_AT`. Unfiltered by state deliberately — closing an issue has to move the watermark *forward*, whereas `states: OPEN` would send it backwards to the next-newest open item.

Cost for the entire 80-repo fleet, inside the discovery search that already runs: **2 GraphQL points** against 5,000/hour. The same search pulling 100 issues and 100 PRs per repo costs 202, which is the number that justified RepoClerk existing in the first place. This stays cheap because of the `first: 1`.

Three tokens now journaled, none redundant:

| token | moves on |
|---|---|
| `pushedAt` | git pushes — gates the expensive artifact re-fetch |
| `updatedAt` | repository record — a collection's title is its description |
| `activityAt` | newest issue or PR update — the bug in #470 |

## Also in this PR, because the change wasn't safe without them

- **`constants.py`** — `SCHEMA_VERSION` was `2` in `sync-all.py` and `3` in `drain.py`, which silently disabled the whole schema-upgrade backfill path. Now imported by both.
- **`__main__` guards on both scripts.** Without them the logic can't be imported by a test at all. This also retires `test_collections.py`'s regex-strip-and-`exec` workaround, which existed only because the guards were missing — a fragile hack that would have silently stopped matching.
- **`staleness_reason()` extracted** as a pure, network-free function.
- **`test_staleness.py`** — 16 assertions covering each token, `pushedAt` precedence, the pre-upgrade path, watermark agreement between the two scripts, and a regression test that fails if anyone swaps the watermark back for `updatedAt`.

## Verification

- All three suites pass: `test_staleness`, `test_collections`, `test_duplicates`.
- Cross-checked live: `search_topic()` and `drain.activity_watermark()` produce **identical** `{pushedAt, updatedAt, activityAt}` for `rana-clamitans-full-body`, `snakeseg`, and `Juvenile_Bearded_Dragon`. A divergence between the two would make every repo look permanently stale, so this is the check that matters most.
- `snakeseg` is the proof case: `pushedAt` 2025-10-07 vs `activityAt` 2026-07-07 — exactly the gap the old comparison could never see.

## Expected on merge

`SCHEMA_VERSION` → 4, so the next `sync-all` queues **all 80 repos** once. That is intended: it writes the new fields and clears the accumulated staleness in one pass. It is also what stops a journal with no `activityAt` from reporting stale on every sweep forever.

Worth watching that first sweep. Per the design doc's Layer 4, the drain is serialized on `repoclerk-writer` and `gh issue list` defaults to 30 results, so 80 repos drain in three batches — and roughly a third of dispatch runs currently fail on concurrent-writer rebase collisions. If the backfill stalls partway, that is the known cause, not this change.

## Review focus

The state filter on the watermark connections is the subtle part — I believe unfiltered is correct for the close case, and I would like that specifically checked. Also whether string `max()` over ISO-8601 UTC is acceptable as the comparison (it is well-defined for `Z`-suffixed timestamps, but it is doing real work here).

Not in this PR: #469 (label gate), the tier gap, Layers 3 and 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)