### PR TITLE
Sweep every 15 minutes instead of hourly

### DIFF
--- a/.github/workflows/sync-all.yml
+++ b/.github/workflows/sync-all.yml
@@ -2,8 +2,9 @@ name: Sync All MorphoDepot Journals
 
 on:
   schedule:
-    # Every 15 minutes, keeping the :23 offset so no run lands on the congested top of the
-    # hour. This is the backstop that makes freshness independent of notifyRepoClerk, which
+    # Every 15 minutes, phased off the original :23 so that none of the four runs lands on
+    # the congested top of the hour (which a plain */15 would do every fourth run).
+    # This is the backstop that makes freshness independent of notifyRepoClerk, which
     # is a silent no-op for non-collaborators (#469) -- so the interval is the real ceiling
     # on staleness for anyone outside the org.
     #

--- a/.github/workflows/sync-all.yml
+++ b/.github/workflows/sync-all.yml
@@ -2,7 +2,21 @@ name: Sync All MorphoDepot Journals
 
 on:
   schedule:
-    - cron: '23 * * * *'    # hourly (offset off the congested top-of-hour; backstop to notifyRepoClerk)
+    # Every 15 minutes, keeping the :23 offset so no run lands on the congested top of the
+    # hour. This is the backstop that makes freshness independent of notifyRepoClerk, which
+    # is a silent no-op for non-collaborators (#469) -- so the interval is the real ceiling
+    # on staleness for anyone outside the org.
+    #
+    # A sweep that finds nothing costs 4 GraphQL points and commits nothing (the dashboard
+    # push short-circuits on an empty diff), so idle runs are close to free on a public repo.
+    #
+    # 15 and not 5: the 80-repo backfill drain took 5m53s, so a 5-minute period is shorter
+    # than a worst-case run. Since this shares `concurrency: repoclerk-writer` with
+    # update-repo and does not cancel in progress, overlapping sweeps would be silently
+    # dropped, and sync-all does not yet dedup against already-open update-requests -- a
+    # stuck drain would collect a duplicate issue per repo per period. Both are prerequisites
+    # for going faster; see design/near-realtime-ingestion.md.
+    - cron: '8,23,38,53 * * * *'
   workflow_dispatch:
 
 concurrency:

--- a/design/near-realtime-ingestion.md
+++ b/design/near-realtime-ingestion.md
@@ -220,9 +220,9 @@ An org webhook cannot cover personal repos. Options, best first:
    already has admin on their own repo. No App permission change, but it is per-repo setup that can
    fail silently on exactly the repos that need it, and it leaves nothing covering repos created
    before the change.
-3. **Do nothing here and rely on Layer 1**, accepting hourly (or whatever the sweep interval becomes)
-   freshness for the personal tier. Defensible only if the sweep interval drops enough to meet the
-   2–3 minute target, which Layer 4 makes affordable.
+3. **Do nothing here and rely on Layer 1**, accepting sweep-interval freshness for the personal tier.
+   The interval is now 15 minutes (see *Sweep interval* below), which is well short of the 2–3 minute
+   target but a long way from the unbounded staleness this started as.
 
 ### Layer 3 — Make failure loud
 
@@ -296,6 +296,36 @@ someone already anticipated this. Two changes, in order of effort:
 
 ---
 
+### Sweep interval
+
+**Now 15 minutes** (`8,23,38,53 * * * *` — keeping the original off-peak offset rather than `*/15`,
+which would land every fourth run on the congested top of the hour). Previously hourly.
+
+Because Layer 1 made the sweep authoritative, this interval *is* the staleness ceiling for anything
+the push path does not cover — which today means every personal-tier repo, and every web-UI action
+on any repo. Measured costs per sweep:
+
+| | |
+|---|---|
+| API | 4 GraphQL points (two topic searches at 2 each) against 5,000/hour — about 1% at 15-minute cadence |
+| Runner time | 25–28 s for a quiet sweep; free, this is a public repo |
+| Commits | **none** when nothing changed — the dashboard push short-circuits on an empty diff, so idle sweeps do not grow the repository every client clones |
+
+**Why not 5 minutes**, which is GitHub's floor and was the original ambition:
+
+1. **A busy sweep outlasts a 5-minute period.** The 80-repo v4 backfill took 5m53s. Since `sync-all`
+   and `update-repo` share `concurrency: repoclerk-writer` with `cancel-in-progress: false`, GitHub
+   keeps one running plus one pending and *discards* the rest — so the schedule would silently
+   degrade precisely under the load that motivated tightening it.
+2. **`sync-all` does not dedup against open requests.** It creates an `update-request` for every
+   stale repo on every run, with no check for one already open. At hourly the drain always clears
+   them in between; at 5 minutes a single stuck drain collects a duplicate issue per repo per period.
+
+Both are prerequisites for going faster, and both are Layer 4 work (writer contention, and a dedup
+check in `sync-all.main()`). Worth noting that GitHub treats scheduled runs on public repos as
+best-effort and drops them under load — the hourly schedule was already firing 16 times in 24 hours,
+not 24 — so any interval here is a target rather than a guarantee.
+
 ## Open question: what belongs in the journal at all
 
 Stated as an open decision rather than a recommendation, because it cuts against something this
@@ -336,8 +366,8 @@ test against.
    archival repos and 500 with several classes live at once.
 4. The open question above — is the cache boundary redrawn, or is the journal instrumented and kept
    as it is?
-5. Sweep interval once Layer 1 lands. Cheap discovery makes minutes plausible; writer contention and
-   git churn are what actually bound it.
+5. ~~Sweep interval once Layer 1 lands.~~ **Decided: 15 minutes** — see *Sweep interval* below.
+   Going below that needs two prerequisites, both listed there.
 
 ## Related
 


### PR DESCRIPTION
One-line schedule change plus the reasoning, now that #475 made the sweep authoritative.

Before Layer 1 the sweep interval barely mattered — the comparison it ran couldn't see issue or PR activity at all, so tightening it would have changed nothing. Now it can, which makes the interval the actual staleness ceiling for everything the push path doesn't cover: every personal-tier repo (the org webhook doesn't reach them) and every web-UI action on any repo. An hour is the wrong ceiling for a classroom.

## Cost, measured

| | per sweep |
|---|---|
| API | **4 GraphQL points** (two topic searches at 2 each) against 5,000/hour — ~1% at this cadence |
| Runner time | 25–28 s quiet; free, public repo |
| Commits | **none** when nothing changed — `git diff --cached --quiet` short-circuits the dashboard push |

That last row is the one that makes this comfortable: idle sweeps add nothing to the history that every extension client clones and pulls.

`8,23,38,53` rather than `*/15`, to keep the existing off-peak offset instead of putting every fourth run on the top of the hour.

## Why not 5 minutes

It's GitHub's floor and was the original ambition, but two things block it:

1. **A busy sweep outlasts the period.** The 80-repo v4 backfill took 5m53s. `sync-all` and `update-repo` share `concurrency: repoclerk-writer` with `cancel-in-progress: false`, so GitHub keeps one running plus one pending and discards the rest — the schedule would silently degrade under precisely the load that motivated tightening it.
2. **`sync-all` has no dedup against open requests.** It creates an `update-request` for every stale repo every run with no check for one already open. At hourly the drain clears them in between; at 5 minutes a single stuck drain collects a duplicate issue per repo per period.

Both are Layer 4 work and both are now recorded in the doc as prerequisites, so this isn't lost.

Also worth knowing: GitHub treats scheduled runs on public repos as best-effort. The hourly schedule was already firing **16 times in 24 hours, not 24** — so any interval here is a target, not a guarantee.

## Doc changes

- New *Sweep interval* section with the decision, the measured costs, and the two prerequisites.
- *Decisions needed* item 5 struck through and resolved.
- Layer 2 option 3 no longer says "hourly".

## Verification

Cron parsed and checked: 4 runs/hour, max gap exactly 15 minutes, none at `:00`, schedule block still well-formed with a single entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)