### PR TITLE
Argue both design docs from scaling, not from today's counts

### DIFF
--- a/design/index-vs-work-state.md
+++ b/design/index-vs-work-state.md
@@ -84,11 +84,11 @@ runs. At target scale a full-fleet pass is not one job; it is a dozen sequential
 phase alone exceeds the timeout.
 
 Worse, the queue is built from GitHub issues — one `gh issue create` per repo. A full-fleet operation
-would open thousands of issues, against a `GITHUB_TOKEN` limit documented at roughly 1,000 REST
-requests per hour per repository. **The issue-as-queue mechanism has a ceiling near a thousand items
-an hour**, which today's fleet never approaches and the target fleet exceeds on a single migration.
-(Worth verifying against current GitHub documentation before relying on the exact figure; the order
-of magnitude is the point.)
+would open thousands of issues, against a `GITHUB_TOKEN` limit documented in the low thousands of
+REST requests per hour. **The issue-as-queue mechanism has a ceiling around a thousand items an
+hour**, which today's fleet never approaches and the target fleet exceeds on a single migration.
+(Verify the exact figure and how it is scoped against current GitHub documentation before relying on
+it — rate limits are per token, and the numbers move. The order of magnitude is the point.)
 
 The design consequence is general: **the fewer full-fleet operations the architecture requires, the
 better it scales.** Journaling work state guarantees frequent per-repo drains driven by fleet-wide
@@ -100,7 +100,7 @@ Every drain commits, regenerates the dashboard, and pushes — to a repository *
 and pulls**.
 
 - **Index-only churn** is bounded by the push rate. Content changes require a git push; measured at 80
-  repos, 57 had not been pushed in over 90 days, and everything Search reads (`widget_search.py:72-135`
+  repos, 57 had not been pushed in over 90 days, and everything Search reads (`widget_search.updateSearchResults`
   — species, modality, spacing, dimensions, size, captions) comes from files committed inside the
   repo and cannot change without one. Publishing is a once-per-repo event, so this scales with *new
   repos*, not with the fleet.

--- a/design/index-vs-work-state.md
+++ b/design/index-vs-work-state.md
@@ -2,103 +2,155 @@
 
 **Status: proposal, for discussion. Nothing here is implemented.**
 Raised by @muratmaga on 2026-08-07, after a day spent fixing the freshness bugs recorded in
-`near-realtime-ingestion.md`. This document is the discussion written down, with the measurements
-that grounded it. It supersedes that file's *Open question: what belongs in the journal at all*.
+`near-realtime-ingestion.md`. It supersedes that file's *Open question: what belongs in the journal
+at all*.
 
-## The proposal, in one paragraph
+## Design target
 
-Take issues and pull requests out of RepoClerk entirely and fetch them live from GitHub, per user,
-at the moment they are needed. Keep everything else — species, modality, spacing, dimensions,
-screenshots, volume size and checksum, curator — in a journal that all repos still appear in,
-personal and org alike, refreshed periodically. Personal repos stay **discoverable** through Search;
-they stop being **advertised** on the dashboard, which becomes the visible benefit of publishing into
-the org.
+**Thousands of personal repos and hundreds of org repos.** Everything below is written against that
+number, not against the fleet as it stands.
 
-The requirement set alongside it: **a repo must be findable within one hour of being published.**
+Today's fleet is 80 repos and the org tier is a week old. Every measurement in this document was
+taken at that size, which is **one to two orders of magnitude** below where this infrastructure needs
+to work. So the counts are useful only for establishing *how a cost scales* — the exponent, not the
+value. An argument of the form "there is not much of X today" is not admissible; X will be a hundred
+times larger, and a design that only works at the current size is not a design.
 
-## What prompted it
+The measurements are reported as `per unit × target` for that reason.
 
-On 2026-08-07 a class stalled because five annotators could not see the issues assigned to them. The
-investigation found three independent faults, all documented in `near-realtime-ingestion.md`: the
-push path is an org webhook and does not reach personal repos; `notifyRepoClerk()` is a silent no-op
-for non-collaborators (#469); and the hourly sweep compared `pushedAt`, which no issue event moves
-(#470, fixed in #475).
+## The proposal
 
-Every one of those failures was about **issues and pull requests on personal repos**. None was about
-species or volume size. That is the observation the proposal is built on.
+Take **issues and pull requests out of the journal for personal repos** and fetch them live from
+GitHub, per user, when needed. Keep everything else — species, modality, spacing, dimensions,
+screenshots, volume size and checksum, curator — in a journal that **all** repos appear in, personal
+and org alike, refreshed periodically.
 
-## Measurements
+Personal repos stay **discoverable** through Search. They stop being **advertised** on the dashboard,
+which becomes the visible benefit of publishing into the org, alongside collections, releases, and
+DOIs.
 
-All taken on 2026-08-07 against the live fleet.
+Requirement set alongside it: **a repo must be findable within one hour of publishing.**
 
-### The fleet is lopsided
+### Optional extension: do the same for org repos
 
-| tier | repos | open issues | open PRs |
-|---|---|---|---|
-| MorphoDepot org | 12 | 6 | 1 |
-| personal accounts | **57** | **116** | **74** |
-| test / scratch orgs | 11 | 13 | 2 |
+Treating org work state the same way — live, not journaled — is a separate decision and is *not* part
+of the proposal above. Arguments both ways, with no appeal to how much data either tier holds today:
 
-95% of open issues and 99% of open pull requests are in personal repos. The cache serves its most
-elaborate machinery — webhook, dispatch, drain, dashboard — to the tier where almost nothing happens.
+**For.** The per-user query is not tier-scoped. `GET /issues?filter=assigned` returns every issue
+assigned to you across all of GitHub in a single call, org and personal together. Keeping org work
+state journaled means taking that response, discarding the org rows, and re-reading those same issues
+from the journal — more code, two paths, and a staler answer, since a live query is fresher than any
+cache. The org tier gains nothing from being cached here; a direct query beats the ~20-second webhook
+path plus the client's next refresh.
 
-### The two kinds of data move at completely different speeds
+**Against.** It is a larger change, and it commits both tiers at once rather than letting the live
+path prove itself on one first. It also supersedes work already shipped: under the narrow proposal
+the sweep still needs `activityAt` (#475) to detect org issue activity, so that stays load-bearing;
+under the extension it becomes a field with no consumer.
 
-Everything the Search tab reads (`widget_search.py:72-135` — species, modality, spacing, dimensions,
-size, captions) comes from files committed inside the repo. It cannot change without a push.
+The narrow version is the reversible one. Take personal out, run a class on it, then decide.
 
-| how recently the repo **content** was pushed | repos |
-|---|---|
-| < 1 day | 1 |
-| 1–7 days | 1 |
-| 7–30 days | 13 |
-| 30–90 days | 8 |
-| **> 90 days** | **57** |
+## Why: the scaling properties
 
-| how recently **issue/PR activity** happened | repos |
-|---|---|
-| < 1 day | 3 |
-| 1–7 days | 6 |
-| 7–30 days | 2 |
-| 30–90 days | 8 |
-| > 90 days | 40 |
-| never | 21 |
+Four arguments, none of which depend on how many repos or issues exist right now.
 
-Two repos saw a push in the last week. Nine saw issue or PR activity. One artifact currently carries
-both, and the slower update frequency set the refresh policy for the faster one.
+### 1. The two data classes have different scaling exponents
 
-### Work state is cheap to fetch live; discovery is not
-
-| query | requests | GraphQL points |
+| | cost scales with | at target |
 |---|---|---|
-| Legacy topic-wide crawl, 80 repos × 100 issues + 100 PRs | 1/page, **search API (30/min)** | **202** |
-| Discovery search + activity watermarks, all 80 repos | 1 (paginated — 5 at 500 repos) | 2 |
-| `viewer.repositories` + topics + issue/PR counts (a curator's own repos) | 1 | **3** |
-| Batched issues + PRs for the heaviest real user's 26 repos | 1 | **14** |
-| Single repo | 1 | 1 |
-| `GET /issues?filter=assigned&state=open` — every issue assigned to me, anywhere | 1 REST call | n/a |
+| **Discovery index** | fleet size | thousands of repos — must be computed once, centrally, and shared |
+| **Work state** | repos *one person* works on | a handful — a property of how people work, not of fleet size |
+
+This is the whole argument, and it is why RepoClerk exists for one and not the other. Measured at 80
+repos: a fleet-wide crawl of issues and PRs costs **202 GraphQL points** on the 30-per-minute search
+endpoint, and grows linearly — roughly 2,500 points at 1,000 repos, which exhausts a 5,000/hour
+budget in two refreshes. The same data fetched per user costs **1–14 points** and *does not move when
+the fleet grows*, because it is bounded by personal involvement.
+
+Journaling work state puts fleet-scaling cost behind data that only ever needs per-user scope.
+
+### 2. Full-fleet operations do not survive an order of magnitude
+
+The schema-v4 backfill on 2026-08-07 gives clean per-repo costs for a whole-fleet pass:
+
+| phase | 80 repos | per repo | at 1,000 | at 5,000 |
+|---|---|---|---|---|
+| discover + queue | 81 s | 1.01 s | 17 min | 84 min |
+| drain | 259 s | 3.24 s | 54 min | 4.5 h |
+| **total** | **5 m 53 s** | | **~1.2 h** | **~6 h** |
+
+Against `timeout-minutes: 30`, a single writer, and a `concurrency` group that discards overlapping
+runs. At target scale a full-fleet pass is not one job; it is a dozen sequential ones, and the queue
+phase alone exceeds the timeout.
+
+Worse, the queue is built from GitHub issues — one `gh issue create` per repo. A full-fleet operation
+would open thousands of issues, against a `GITHUB_TOKEN` limit documented at roughly 1,000 REST
+requests per hour per repository. **The issue-as-queue mechanism has a ceiling near a thousand items
+an hour**, which today's fleet never approaches and the target fleet exceeds on a single migration.
+(Worth verifying against current GitHub documentation before relying on the exact figure; the order
+of magnitude is the point.)
+
+The design consequence is general: **the fewer full-fleet operations the architecture requires, the
+better it scales.** Journaling work state guarantees frequent per-repo drains driven by fleet-wide
+activity. An index-only journal drains only on push.
+
+### 3. Journal churn is driven by whatever is journaled
+
+Every drain commits, regenerates the dashboard, and pushes — to a repository **every client clones
+and pulls**.
+
+- **Index-only churn** is bounded by the push rate. Content changes require a git push; measured at 80
+  repos, 57 had not been pushed in over 90 days, and everything Search reads (`widget_search.py:72-135`
+  — species, modality, spacing, dimensions, size, captions) comes from files committed inside the
+  repo and cannot change without one. Publishing is a once-per-repo event, so this scales with *new
+  repos*, not with the fleet.
+- **Work-state churn** is bounded by fleet-wide issue and pull-request activity, which scales with
+  fleet size *multiplied by* per-repo activity. It is the faster-growing term by a wide margin.
+
+At target scale the second term is what makes the dashboard rebuild — currently 3 s over 80 repos,
+itself O(fleet) — run on every issue comment anywhere in the fleet.
+
+### 4. Git as the client transport has a ceiling
+
+Journals average ~4.4 KB. At thousands of repos the set is tens of megabytes, cloned and then pulled
+forever by every extension user, with history accumulating on top. `refreshRepoClerk()` already
+carries a `REPOCLERK_SIZE_LIMIT_MB = 100` guard that deletes and re-clones when the working copy
+crosses 100 MB — a guard whose existence says someone already saw this coming.
+
+This is a problem for the index regardless of this proposal, and it is worth solving separately:
+publish `docs/` off the branch clients clone, and consider a compact searchable index (the handful of
+fields Search actually filters on, a few hundred bytes per repo) with full detail fetched lazily,
+served as a conditional GET rather than a git history. But note the direction of the interaction —
+**removing work state from the journal reduces both its size and its churn**, so it makes this ceiling
+further away rather than nearer.
+
+## Measured costs
+
+Taken 2026-08-07 at 80 repos. Reported to establish scaling, per the note at the top.
+
+| query | requests | GraphQL points | scales with |
+|---|---|---|---|
+| Legacy topic-wide crawl (100 issues + 100 PRs per repo) | 1 per 100 repos, **search API (30/min)** | **202** | fleet |
+| Discovery search + change tokens | 1 per 100 repos | 2 | fleet |
+| `viewer.repositories` + topics + counts | 1 | **3** | user's own repos |
+| Batched issues + PRs across a user's 26 repos | 1 | **14** | user's repos |
+| Single repo | 1 | 1 | — |
+| `GET /issues?filter=assigned&state=open` | 1 REST call | n/a | — |
 
 Limits: core 5,000/hour, GraphQL 5,000 points/hour, **search 30/minute**. The search endpoint is the
-strict one, and it is the one the legacy design depended on.
+strict one, and the legacy design depended on it.
 
-`GET /issues?filter=assigned` is the important entry in that table. It is a real-time REST endpoint,
-not search-index backed, and it answers the Annotate tab's question directly. Tested: 13 open issues
-across 7 repos in one call, including the personal repo from the failed class.
+`GET /issues?filter=assigned` is the important row. It is a real-time REST endpoint, not search-index
+backed, and it answers the Annotate tab's question directly for both tiers at once — tested, 13 open
+issues across 7 repos in one call, org and personal together.
 
-### Per-user fan-out is small and does not grow with the fleet
-
-Across all 80 journals, counting every login with an assigned issue, an authored PR, or a CURATOR
-entry: **49 users, median 1 repo, mean 2.0, max 26.** Thirty-seven of the 49 touch exactly one repo.
-The 26 is the project lead.
-
-This is the crux. Legacy cost scaled with **fleet size** — 202 points at 80 repos, roughly 1,250 at
-500, four refreshes an hour before lockout. Live per-user cost scales with **how many repos a person
-actually works on**, which does not move when the fleet grows.
+Per-user fan-out across the 49 logins appearing in journals: **median 1 repo, mean 2.0, max 26.** This
+is the number that does not scale with the fleet, and the one the design should lean on.
 
 ## Was this not the original design?
 
-No. Work state was in the journal from the first commit that created journals
-([50cb005](https://github.com/MorphoDepot/RepoClerk/commit/50cb005), 2026-03-23): `schemaVersion: 1`
+No. Work state was journaled from the first commit that created journals
+([50cb005](https://github.com/MorphoDepot/RepoClerk/commit/50cb005), 2026-03-23) — `schemaVersion: 1`
 already carried `openIssues` with assignees and `openPRs`. There was never a discovery-only phase.
 
 The original README says why:
@@ -107,163 +159,141 @@ The original README says why:
 > API directly on every refresh** — causing latency and rate-limit issues with multiple concurrent
 > users.
 
-That was accurate, and caching all three was the right call — because at the time all three *were*
-fleet-wide. `issueList()` and `prList()` both call `ghTopicData()`, the topic-wide crawl, and then
-filter client-side for entries naming the current user. The extension answered "what am I assigned?"
-by downloading the whole fleet and searching it locally.
+That was accurate, and caching all three was correct — because at the time all three *were*
+fleet-wide. `issueList()` and `prList()` both call `ghTopicData()`, the topic-wide crawl, then filter
+client-side for entries naming the current user. The extension answered "what am I assigned?" by
+downloading the whole fleet and searching it locally.
 
 So nothing was switched and no decision was skipped. What changed is that two of the three questions
-can now be asked directly. The work state was expensive because of **how it was fetched**, not
-because of what it is. This proposal is therefore not a reversal of the original design — it is the
-original design, plus a cheaper way to ask two of its three questions.
+can now be asked at user scope instead of fleet scope. The work state was expensive because of **how
+it was fetched**, not because of what it is. This proposal is the original design plus a cheaper way
+to ask two of its three questions.
 
-## The proposal
+## Shape
 
-| | lives in | refreshed | why |
+| | lives in | refreshed | scales with |
 |---|---|---|---|
-| **Discovery index** — species, modality, spacing, dimensions, screenshots, volume size, checksum, curator, collection membership | RepoClerk, **all repos** | push-gated, hourly | changes ~twice a week, expensive to gather, shared by everyone |
-| **Work state** — open issues, open PRs, draft status, assignees | nowhere; fetched live per user | on demand | changes constantly, cheap to fetch, only ever needed for a handful of repos |
-| **Dashboard, collections, releases, DOI** | RepoClerk, **org repos only** | as today | the visible differentiator |
+| **Discovery index** — species, modality, spacing, dimensions, screenshots, volume size, checksum, curator, collection membership | RepoClerk, **all repos** | push-gated, hourly | new repos and pushes |
+| **Work state** — open issues, open PRs, draft status, assignees | live, per user (personal repos; org too under the extension) | on demand | one person's repos |
+| **Dashboard, collections, releases, DOI** | RepoClerk, **org repos only** | as today | org fleet |
 
-Per tab, after the split:
+Per tab:
 
-- **Search** — reads the index. Every repo present, personal included. No live API at all.
+- **Search** — reads the index. Every repo present, personal included. No live API.
 - **Annotate** — `GET /issues?filter=assigned`, filtered to `morphodepot`-topic repos. One real-time
-  call. No cache, no staleness, no notify.
+  call, both tiers.
 - **Review** — `viewer.repositories(ownerAffiliations: OWNER)` filtered by topic, plus one batched
-  query for issues and PRs. 3 points, real-time. For in-org repos the journaled `curator` field
-  still supplies "repos I curate", since the org owns them rather than the member.
+  query for issues and PRs.
 - **Release / Collections** — unchanged, org-only already.
 
-### One place where a tier distinction survives, stated plainly
+### One place a tier distinction survives, stated plainly
 
-**Work state has exactly one source everywhere: live.** No view reads issues or PRs from two places,
-and no repo's issues behave differently from another's. That is the property worth having, and it is
-what makes this different from the earlier draft of this proposal, which split by *tier* — org
-cached, personal live — and was dropped precisely because it made two repos behave differently.
+**Work state has one source per repo, whichever variant is chosen.** No view reads the same repo's
+issues from two places. That is the property worth having, and it is what the earlier tier-split
+draft of this proposal failed.
 
-But *which repos concern me* is not uniform in the Review tab, and pretending otherwise would be
-overclaiming. A curator's list is the union of two things:
+But *which repos concern me* is not uniform in Review, and pretending otherwise would be
+overclaiming. A curator's list is a union:
 
 | | source | why |
 |---|---|---|
-| my own repos carrying the topic | live `viewer.repositories(ownerAffiliations: OWNER)` | I own them, so GitHub can enumerate them for me directly |
-| org repos where `CURATOR` names me | the index | the org owns them, not me, so an owner-keyed query cannot find them — and `CURATOR` is a committed file, hence index data |
+| my own repos carrying the topic | live `viewer.repositories(ownerAffiliations: OWNER)` | I own them, so GitHub enumerates them directly |
+| org repos where `CURATOR` names me | the index | the org owns them, so an owner-keyed query cannot find them — and `CURATOR` is a committed file, hence index data |
 
-That is a genuine asymmetry. Two defenses, and readers should judge whether they hold:
+Two defenses, which readers should judge:
 
-1. It is a *union*, not a *branch*. There is no "if org then A else B" — both queries run and the
-   results merge. Nothing has to classify a repo before deciding how to treat it.
+1. It is a *union*, not a *branch*. Both queries run and merge; nothing classifies a repo before
+   deciding how to treat it.
 2. The org half is index data by nature. `CURATOR` lives in a file in the repo, so it is push-gated
-   and belongs in the index on the same grounds as species and modality. Reading it from there is not
-   a concession; it is the rule being applied consistently.
+   and belongs in the index on the same grounds as species. Reading it there is the rule applied
+   consistently, not an exception.
 
-Annotate has no such asymmetry — `GET /issues?filter=assigned` spans org and personal repos in one
-call. Search has none either. The Review repo-list is the only place a tier distinction remains, and
-it exists because GitHub's ownership model, not our design, makes "repos I curate but do not own"
-unanswerable without stored state.
+Annotate has no such asymmetry, and neither does Search. The Review repo-list is the only place a
+tier distinction remains, and it exists because GitHub's ownership model makes "repos I curate but do
+not own" unanswerable without stored state.
 
 ## What this removes
 
-- **The entire failure class from 2026-08-07.** No journal entry for issues means nothing to go
-  stale. The classroom outage becomes structurally impossible rather than instrumented against.
-- **#469 evaporates.** `notifyRepoClerk()` exists to refresh journals after issue and PR events. With
-  work state gone and the index push-gated, it has no remaining job — delete it rather than fix the
-  label gate and its loop-termination blocker.
-- **The tier gap stops being a defect.** The org webhook covers the tier that keeps a cache. That
-  alignment has been treated as a bug; it becomes the design.
-- **Writer contention and git churn collapse.** 57 repos producing no commits for months means the
-  repository every client clones goes nearly static, which also retires the `REPOCLERK_SIZE_LIMIT_MB`
-  guard and most of `near-realtime-ingestion.md`'s Layer 4.
-- **The sweep can return to hourly** and still meet the one-hour requirement with the full hour as
-  margin. The 15-minute cadence set in #556 exists because work state is currently journaled.
-
-Honest consequence: **the `activityAt` watermark shipped in #475 becomes unnecessary under this
-design.** It exists to tell a sweep when issue activity happened; if issues are not journaled, it has
-no consumer. It was the right fix for the current architecture and should stay until this lands. Its
-durable output is the finding that `Repository.updatedAt` does not move on issue activity, which
-would have cost the next person a day.
+- **The 2026-08-07 failure class.** No journal entry for issues means nothing to go stale for personal
+  repos. The classroom outage becomes structurally impossible rather than instrumented against.
+- **#469 becomes deletable rather than fixable**, under either variant. `notifyRepoClerk()` exists to
+  refresh journals after issue and PR events; with the index push-gated and the webhook already
+  covering org repos, it has no remaining job — and its loop-termination blocker goes with it.
+- **The tier gap stops being a defect.** The org webhook covers the tier that keeps a work-state
+  cache. That alignment has been treated as a bug; under the narrow proposal it becomes the design.
+- **Churn and full-fleet cost fall**, which is what buys headroom for the target scale.
 
 ## What it costs
 
-- **A second artifact to keep coherent.** They are independent, which is the point, but it is two
-  things rather than one.
-- **Fleet-wide duplicate-volume detection** keeps working (checksum is index data), but any
-  cross-repo analysis of *issues* would no longer have a corpus to run against. Nothing does that
-  today.
-- **Live calls fail when GitHub does.** Worth stating precisely, because the obvious version of this
-  concern is wrong: there is no offline resilience today to lose. `refreshRepoClerk()` returns `None`
-  when `git pull` fails, and `ghTopicData()` and `morphoRepos()` then return `[]` — the journals
-  already on disk are discarded exactly when they would be most useful. The docstring claims a
-  "fallback to direct API" that does not exist.
+- **A second artifact to keep coherent**, though they are independent by design.
+- **Live calls fail when GitHub does.** The obvious version of this concern is wrong — there is no
+  offline resilience to lose. `refreshRepoClerk()` returns `None` when `git pull` fails, and
+  `ghTopicData()` and `morphoRepos()` then return `[]`, discarding journals already on disk. The
+  docstring claims a "fallback to direct API" that does not exist. *This is extension-side code and
+  should be confirmed there before this document is used to argue the point.*
 
-  The split arguably *improves* this. A failed live call can say "could not reach GitHub"; an empty
-  journal-backed list says nothing, and is indistinguishable from "no work assigned to you" — the
-  ambiguity that made the 2026-08-07 investigation take a full day, and the same complaint as
-  SlicerMorph/SlicerMorphoDepot#212. A one-line fix to return the existing clone path on pull failure
-  is worth doing regardless of this proposal.
-- **Per-user API budget**, measured above at 1–14 points per refresh against 5,000/hour, with each
-  client authenticating as its own user so a class of thirty has thirty separate budgets.
+  The split arguably improves the failure mode: a failed live call can say "could not reach GitHub,"
+  whereas an empty journal-backed list is indistinguishable from "no work assigned to you" — the
+  ambiguity behind SlicerMorph/SlicerMorphoDepot#212 and much of the 2026-08-07 investigation.
+- **Per-user API budget**, measured above, with each client authenticating as its own user, so a class
+  of thirty has thirty separate budgets.
 
 ## Meeting the one-hour requirement
 
-The index is push-gated and pushes are rare, so an hourly sweep satisfies it with the whole hour
-spare. The normal case is much faster: publishing already runs through the intake App, so the App can
-dispatch an index refresh by name at publish time — seconds, no webhook scope problem, no label, no
-org-versus-personal distinction. The sweep becomes the backstop for a failed dispatch, which is the
-correct role for a backstop.
+The index is push-gated, so an hourly sweep satisfies it with the hour spare. The normal case is much
+faster: publishing already runs through the intake App, so the App can dispatch an index refresh by
+name at publish time — seconds, no webhook scope problem, no label, no tier distinction. The sweep
+becomes the backstop for a failed dispatch, which is the correct role for a backstop.
 
-One caveat: `sync-all` discovers repos through GitHub's topic search, which is index-backed and lags
-minutes. Within an hour that is comfortable, and the publish-time dispatch bypasses it by naming the
-repo directly.
+At target scale, note that the sweep's *discovery* phase pages the topic search at 100 repos per
+request, so it grows linearly in requests while staying far inside the search limit; it is the queue
+and drain phases in §2 that need rework, not discovery.
 
 ## Open questions
 
 1. **Is "discoverable but not advertised" the right policy** for personal repos? It is a visible
-   change — the dashboard drops from 80 tiles to 12 — and it should be a deliberate product decision,
-   not a side effect. What are owners of the 57 personal repos told?
-2. **Is the org tier the destination most data reaches, or a small curated shelf?** If the first, this
-   is clearly right. If the second, RepoClerk runs a webhook, a drain, and a dashboard for twelve
-   repos holding six issues.
-3. **How does a repo move between tiers?** A personal repo later published into the org needs its
+   change and should be a deliberate product decision. What are personal-repo owners told?
+2. **What is the org tier for?** Not "how much is in it" — it is a week old and the answer would be an
+   artifact of that. Is it the destination most datasets are expected to reach once they are finished,
+   or a curated subset with the rest living permanently in personal accounts? The answer sets whether
+   hundreds of org repos is a floor or a ceiling, and therefore how much the org-only presentation
+   layer has to scale.
+3. **Adopt the extension, or only the narrow proposal?** See the arguments above.
+4. **How does a repo move between tiers?** A personal repo later published into the org needs its
    index entry and dashboard presence to follow it.
-4. **What happens to the extension's offline behavior** — is the one-line clone-path fallback part of
-   this work or separate?
-5. **Which of `near-realtime-ingestion.md`'s four layers survive?** Not all of them lapse, and the
-   distinction matters:
+5. **Rework the queue and full-fleet path.** §2 says the issue-as-queue design and the serial drain do
+   not survive the target scale, independently of this proposal. Batching, resumability, and a queue
+   that is not GitHub issues are all implied. Does that happen alongside this or before it?
+6. **Which of `near-realtime-ingestion.md`'s layers survive?**
 
    | layer | under this proposal |
    |---|---|
-   | 1 — authoritative sweep (`activityAt`) | **lapses** — no consumer once issues leave the journal |
-   | 2 — close the tier gap (App events) | **lapses** for work state; the index still wants a push signal, but the publish-time App dispatch covers it |
-   | 3 — make failure loud | **still required, unchanged.** A failed index drain is exactly as invisible as a failed work-state drain was. Drain alarms and a freshness metric apply to the index verbatim — a stale index means a repo silently missing from Search, which is the same class of bug that went unnoticed for seven weeks |
-   | 4 — scale to 500 repos | **mostly lapses** — churn collapses and contention stops binding, but the batched-query and pagination work moves to the client |
+   | 1 — authoritative sweep (`activityAt`) | survives under the narrow version (org work state still journaled); lapses under the extension |
+   | 2 — close the tier gap (App events) | lapses for work state; the index still wants a push signal, which the publish-time App dispatch covers |
+   | 3 — make failure loud | **still required, unchanged.** A failed index drain is exactly as invisible as a failed work-state drain, and a stale index means a repo silently missing from Search — the same class of failure that went seven weeks unnoticed |
+   | 4 — scale | **more urgent, not less.** §2 and §4 above are Layer 4 work restated against the real target |
 
-6. **Sequencing.** #469 and the Layer 2 App-permission decision both become moot if this lands. Doing
-   either first is wasted effort; doing neither leaves known bugs open while this is discussed.
+7. **The extension's offline behavior** — is the one-line clone-path fallback part of this work or
+   separate?
 
 ## Interim guidance for instructors
 
-Until something here changes, the current behavior is worth stating plainly, because it affects how
-a class should be run:
+Until something here changes, the current behavior affects how a class should be run:
 
 - Creating and assigning issues triggers **no** notification path at all, for anyone. It always waits
   for the sweep — currently up to 15 minutes.
-- Publishing a repo does notify, but that only works for accounts with triage permission on RepoClerk
-  (#469). For everyone else it is the sweep again.
+- Publishing a repo does notify, but only for accounts with triage permission on RepoClerk (#469).
 - A student opening a PR or clicking *Request review* is on the same path, so **the delay applies
   during class, not just to setup**.
-- Practical advice: publish the repo and create and assign every issue at least 20 minutes before the
-  session. Sweeps run at `:08`, `:23`, `:38`, `:53`.
+- Publish the repo and create and assign every issue at least 20 minutes before the session. Sweeps
+  run at `:08`, `:23`, `:38`, `:53`.
 - An org owner can force it immediately with
   `gh workflow run sync-all.yml --repo MorphoDepot/RepoClerk`. Nobody without write access here can.
 
 ## Related
 
-- `design/near-realtime-ingestion.md` — the freshness architecture, the 2026-08-07 incident, and the
-  four-layer plan this proposal partly supersedes
-- #469 — label gate; would be deleted rather than fixed
+- `design/near-realtime-ingestion.md` — the freshness architecture and the 2026-08-07 incident
+- #469 — label gate; deletable rather than fixable under either variant
 - #470 / #475 — the `pushedAt` staleness bug and the `activityAt` watermark that fixed it
-- #556 — the 15-minute sweep, which could return to hourly under this proposal
-- SlicerMorph/SlicerMorphoDepot#211, #212 — the extension-side investigation and the empty-list
-  ambiguity
+- #556 — the 15-minute sweep
+- SlicerMorph/SlicerMorphoDepot#211, #212 — extension-side investigation and the empty-list ambiguity

--- a/design/near-realtime-ingestion.md
+++ b/design/near-realtime-ingestion.md
@@ -304,7 +304,8 @@ Against `timeout-minutes: 30`, a single writer, and a concurrency group that dis
 runs. **A whole-fleet operation — a schema migration, a recovery, a backfill — does not survive one
 order of magnitude.** The queue phase alone exceeds the timeout, and since the queue is built from
 GitHub issues at one `gh issue create` per repo, it also runs into `GITHUB_TOKEN`'s documented limit
-of roughly 1,000 REST requests per hour per repository.
+in the low thousands of REST requests per hour. (Rate limits are scoped per token;
+verify the current figure before relying on it — the order of magnitude is the point.)
 
 So the architectural rule is: **minimize how often anything must touch the whole fleet.** Batching,
 resumability, and a work queue that is not GitHub issues are all implied, and

--- a/design/near-realtime-ingestion.md
+++ b/design/near-realtime-ingestion.md
@@ -285,16 +285,40 @@ passed.
 - **Publish a freshness metric**: max and median `now - journalUpdatedAt` against `activityAt`,
   on the dashboard. One number that would have made all of this obvious on day one.
 
-### Layer 4 — Make it affordable at 5–10× the current size
+### Layer 4 — Make it affordable at the target scale
 
-Today's fleet is 80 repos. The design should hold at 500.
+**The design target is thousands of personal repos and hundreds of org repos.** Today's fleet is 80,
+which is one to two orders of magnitude below that, so the measurements below establish how each cost
+*scales* rather than whether it is currently acceptable. An earlier draft of this section reasoned
+against 500 repos; that was too small a target and the numbers have been restated.
+
+The finding that matters most at that size, measured on the schema-v4 backfill of 2026-08-07:
+
+| phase of a full-fleet pass | 80 repos | per repo | at 1,000 | at 5,000 |
+|---|---|---|---|---|
+| discover + queue | 81 s | 1.01 s | 17 min | 84 min |
+| drain | 259 s | 3.24 s | 54 min | 4.5 h |
+| **total** | **5 m 53 s** | | **~1.2 h** | **~6 h** |
+
+Against `timeout-minutes: 30`, a single writer, and a concurrency group that discards overlapping
+runs. **A whole-fleet operation — a schema migration, a recovery, a backfill — does not survive one
+order of magnitude.** The queue phase alone exceeds the timeout, and since the queue is built from
+GitHub issues at one `gh issue create` per repo, it also runs into `GITHUB_TOKEN`'s documented limit
+of roughly 1,000 REST requests per hour per repository.
+
+So the architectural rule is: **minimize how often anything must touch the whole fleet.** Batching,
+resumability, and a work queue that is not GitHub issues are all implied, and
+[`index-vs-work-state.md`](index-vs-work-state.md) argues that removing work state from the journal
+is the change that most reduces full-fleet pressure, since index drains are push-gated while
+work-state drains follow fleet-wide issue activity.
 
 Measured on 2026-08-07: a steady-state `sync-all` run is 25–28 s, almost entirely checkout and setup
 — the discovery search is a single page. `journals/` is 352 KB across 80 files (~4.4 KB each),
 `docs/` is 264 KB, `.git` is 3.9 MB.
 
-**Discovery scales fine.** 500 repos is 5 search pages. This is not the constraint at any plausible
-size.
+**Discovery scales fine.** The topic search pages at 100 repos per request, so it grows linearly in
+requests — 50 at 5,000 repos — while staying far inside the 30-per-minute search limit at any sane
+cadence. This is not the constraint at target scale.
 
 **The drain does not, for two reasons.**
 
@@ -303,9 +327,13 @@ HEAD against the volume URL — an S3 redirect chain on a multi-GB object — an
 every refresh, including one triggered by a single issue comment. Split the two signals by cost:
 **`pushedAt` gates the expensive artifact fetches** (accession, captions, `CURATOR`, checksum, volume
 HEAD — none of which can change without a push), **`activityAt` gates a cheap issues/PRs-only
-refresh**. Then batch that cheap refresh with GraphQL aliases (`r0: repository(...) r1: ...`), so 500
-repos cost ~10 requests rather than 500. Verify node-count and complexity limits before fixing a
-batch size.
+refresh**. Then batch that cheap refresh with GraphQL aliases (`r0: repository(...) r1: ...`), so a
+fleet of any size costs one request per batch of ~50 rather than one per repo. Verify node-count and
+complexity limits before fixing a batch size.
+
+That split is what turns the 3.24 s/repo drain measured above into something proportional to what
+actually changed. It matters more the larger the fleet gets, and it is moot for work state entirely
+if [`index-vs-work-state.md`](index-vs-work-state.md) is adopted.
 
 *There is one writer and it already collides.* The `repoclerk-writer` concurrency group keeps one
 run in flight and one pending and cancels the rest; two long runs were cancelled outright on
@@ -313,17 +341,23 @@ run in flight and one pending and cancels the rest; two long runs were cancelled
 properly — a queue rather than a lock that drops work — matters more as the fleet grows.
 
 **Git churn is the wall, and it is client-visible.** Every drain regenerates `docs/` and commits it.
-At 500 repos with a tightened sweep interval that is hundreds of commits a day, each rewriting a
-growing generated tree, on a repository **every extension user clones**. `refreshRepoClerk()` does a
+Commit volume follows whatever is journaled: an index-only journal changes on push, while a journal
+carrying work state changes on fleet-wide issue and pull-request activity — the second term grows with
+fleet size *multiplied by* per-repo activity, so it is the one that gets away from you. Either way
+each commit rewrites a generated tree that is itself O(fleet), on a repository **every extension user
+clones**. `refreshRepoClerk()` does a
 `--depth 1` clone then pulls forever after, and there is already a `REPOCLERK_SIZE_LIMIT_MB = 100`
 guard that deletes and re-clones when the working copy crosses 100 MB — a guard whose existence says
 someone already anticipated this. Two changes, in order of effort:
 
 1. **Get `docs/` off the branch clients clone** (`gh-pages` or an orphan branch). Small change, large
    effect: presentation churn stops landing in every user's working copy.
-2. **Reconsider git as the client transport.** At 500 repos the whole journal set is ~2.2 MB. One
-   aggregated JSON fetched with an `ETag` is a single conditional GET — no history, no size guard, no
-   periodic re-clone. Git is supplying history that nothing reads, for data that is a cache.
+2. **Reconsider git as the client transport.** Journals average ~4.4 KB, so the set is tens of
+   megabytes at target scale — cloned, then pulled forever, with history accumulating on top, by every
+   extension user. Git is supplying history that nothing reads, for data that is a cache. A
+   conditional GET against a single artifact has no history and no size guard; if even that is too
+   large, a compact index carrying only the fields Search filters on (a few hundred bytes per repo)
+   with detail fetched lazily keeps the client payload flat as the fleet grows.
 
 ---
 
@@ -400,8 +434,11 @@ test against.
    structural, not a misconfiguration — see *Evidence*.
 2. Layer 2: App-installation events (a permission increase on an App deliberately narrowed to
    Contents-only), per-repo webhooks, or neither?
-3. Layer 4: is 500 repos the number to design for? The answer differs sharply between 500 dormant
-   archival repos and 500 with several classes live at once.
+3. ~~Layer 4: is 500 repos the number to design for?~~ **Answered 2026-08-07: the target is thousands
+   of personal repos and hundreds of org repos.** Today's 80 is one to two orders of magnitude below
+   that, so measurements taken now establish scaling exponents, not acceptability. What remains open
+   is the mix — how much of that fleet is dormant archival material versus classes live at once —
+   since that sets the activity term rather than the fleet term.
 4. ~~The open question above — is the cache boundary redrawn, or is the journal instrumented and kept
    as it is?~~ **Superseded 2026-08-07** by [`index-vs-work-state.md`](index-vs-work-state.md), which
    turns it into a concrete proposal with measurements. Still undecided, but the question now has a


### PR DESCRIPTION
Two corrections, both from @muratmaga.

## 1. Stop arguing from current volume

Both documents leaned on today's counts — "95% of issues are in personal repos," "twelve repos holding six issues." **The org tier is a week old.** Using its current size to argue about its future is a sampling error, and I did it repeatedly, including in a merged document.

**The design target is thousands of personal repos and hundreds of org repos.** Today's 80 is one to two orders of magnitude below that, so measurements taken now establish *how a cost scales*, not whether it is currently acceptable.

Every volume-based inference is replaced with a property that holds at any size:

- **Index cost scales with fleet; work-state cost scales with the repos one person works on.** That is the entire argument for treating them differently, and it needs no appeal to how much of either exists.
- **Journal churn follows whatever is journaled** — push rate for an index, fleet-wide issue activity for work state. The second term grows with fleet size *multiplied by* per-repo activity.
- **Git as client transport has a ceiling** that arrives with fleet size, not with activity.

## 2. The finding that came out of taking the target seriously

Re-reading the v4 backfill's step timings gives clean per-repo costs for a whole-fleet pass:

| phase | 80 repos | per repo | at 1,000 | at 5,000 |
|---|---|---|---|---|
| discover + queue | 81 s | 1.01 s | 17 min | 84 min |
| drain | 259 s | 3.24 s | 54 min | 4.5 h |
| **total** | **5 m 53 s** | | **~1.2 h** | **~6 h** |

Against `timeout-minutes: 30`, a single writer, and a concurrency group that discards overlapping runs. **A whole-fleet operation — schema migration, recovery, backfill — does not survive one order of magnitude.** The queue phase alone exceeds the timeout.

And because the queue is built from GitHub issues at one `gh issue create` per repo, a full-fleet pass would open thousands of issues against `GITHUB_TOKEN`'s documented ~1,000 REST requests/hour. **The issue-as-queue mechanism has a ceiling near a thousand items an hour** — never approached today, exceeded by a single migration at target scale. Worth verifying the exact figure against current GitHub docs; the order of magnitude is the point.

This is independent of the index/work-state proposal and belongs to Layer 4 either way.

## 3. Restructured to the scope actually asked for

The previous version of `index-vs-work-state.md` proposed taking work state live for **all** repos. The ask was **personal repos only**, and I generalized without flagging it.

Now: the proposal is the narrow version. Extending it to org repos is an explicitly separate decision with arguments both ways — for, that the per-user query isn't tier-scoped and live is fresher than any cache; against, that it is larger, commits both tiers at once, and supersedes `activityAt` (#475), which stays load-bearing under the narrow version.

## Review focus

The extrapolations in §2 assume the measured per-repo costs stay linear. If anything in `process_repo()` or the queue phase is superlinear in fleet size, the numbers are optimistic and the conclusion gets stronger, not weaker — but I would like that checked rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)