### PR TITLE
Detect the first issue on a freshly published repo

### DIFF
--- a/scripts/sync-all.py
+++ b/scripts/sync-all.py
@@ -102,17 +102,22 @@ def staleness_reason(journal, remote):
     the hard way -- an earlier version of this fix compared updatedAt and would have
     changed nothing at all.
 
-    A journal written before this field existed has no activityAt.  Comparing "" against a
-    real timestamp would report every repo stale on every sweep forever, so those fall
-    through to the schemaVersion check, which re-drains each exactly once and writes it.
+    Absent (None) and empty ("") are deliberately different, and conflating them is a bug
+    with teeth.  None means the journal predates the field, so there is nothing to compare
+    and it falls through to the schemaVersion check, which re-drains it once and writes it.
+    "" means the repo genuinely has no issues or pull requests yet -- which is exactly the
+    state a freshly published repo is in, so the *first* issue ever opened on it must be
+    detected here.  Nothing else would catch it: creating an issue moves neither pushedAt
+    nor updatedAt.  A truthiness test would skip that comparison and the repo would never
+    be re-drained.
     """
     if journal is None:
         return "missing"
     if journal.get("pushedAt", "") != remote["pushedAt"]:
         return "stale"
-    if journal.get("updatedAt") and journal["updatedAt"] != remote["updatedAt"]:
+    if journal.get("updatedAt") is not None and journal["updatedAt"] != remote["updatedAt"]:
         return "metadata"
-    if journal.get("activityAt") and journal["activityAt"] != remote["activityAt"]:
+    if journal.get("activityAt") is not None and journal["activityAt"] != remote["activityAt"]:
         return "activity"
     if journal.get("schemaVersion", 1) < SCHEMA_VERSION:
         return "schema-upgrade"
@@ -141,13 +146,17 @@ def main():
         try:
             with open(path) as f:
                 data = json.load(f)
+            # None, not "", when a field is absent: a journal written before the field
+            # existed must be distinguishable from one where the field is legitimately
+            # empty (a repo that has never had an issue or PR). Collapsing the two makes
+            # the first issue on a new repo undetectable -- see staleness_reason.
             journaled_repos[nwo] = {"path": path, "pushedAt": data.get("pushedAt", ""),
-                                    "updatedAt": data.get("updatedAt", ""),
-                                    "activityAt": data.get("activityAt", ""),
+                                    "updatedAt": data.get("updatedAt"),
+                                    "activityAt": data.get("activityAt"),
                                     "schemaVersion": data.get("schemaVersion", 1)}
         except Exception:
-            journaled_repos[nwo] = {"path": path, "pushedAt": "", "updatedAt": "",
-                                    "activityAt": "", "schemaVersion": 0}
+            journaled_repos[nwo] = {"path": path, "pushedAt": "", "updatedAt": None,
+                                    "activityAt": None, "schemaVersion": 0}
 
     print(f"Found {len(journaled_repos)} existing journal file(s)")
 

--- a/scripts/test_staleness.py
+++ b/scripts/test_staleness.py
@@ -137,6 +137,11 @@ def test_absent_and_empty_are_not_the_same():
     check("same treatment for updatedAt",
           sync_all.staleness_reason(journal(updated=None, schema=CURRENT - 1),
                                     remote(updated=LATER)) == "schema-upgrade")
+    # The GitHub API always returns a real updatedAt, so "" should not occur here in
+    # practice -- but the guard must behave the same way for both fields regardless.
+    check("empty updatedAt is compared too, not skipped",
+          sync_all.staleness_reason(journal(updated=""),
+                                    remote(updated=LATER)) == "metadata")
 
 
 def test_pre_upgrade_journal_upgrades_once_not_forever():
@@ -163,10 +168,11 @@ def test_pushed_at_takes_precedence():
 
 
 def test_unreadable_journal_is_re_queued():
-    # main() represents an unparseable journal file as empty strings + schemaVersion 0.
+    # main() represents an unparseable journal file as pushedAt="" (which always mismatches
+    # a real timestamp, so this fires first), updatedAt=None, activityAt=None, schemaVersion=0.
     check("corrupt journal record -> re-queued rather than skipped",
           sync_all.staleness_reason(
-              {"pushedAt": "", "updatedAt": "", "activityAt": "", "schemaVersion": 0},
+              {"pushedAt": "", "updatedAt": None, "activityAt": None, "schemaVersion": 0},
               remote()) == "stale")
 
 

--- a/scripts/test_staleness.py
+++ b/scripts/test_staleness.py
@@ -108,14 +108,46 @@ def test_repo_metadata_change():
           sync_all.staleness_reason(journal(), remote(updated=LATER)) == "metadata")
 
 
-def test_pre_upgrade_journal_upgrades_once_not_forever():
-    """A journal written before activityAt existed must not be reported stale forever.
+def test_first_issue_on_a_freshly_published_repo():
+    """The classroom flow, and the case an earlier version of this fix silently missed.
 
-    Comparing "" against a live timestamp would match on every sweep, re-queueing the
-    whole fleet hourly for good.  Empty values fall through to the schema check, which
-    re-drains each repo exactly once and writes the field.
+    A repo published with no issues yet is journaled with activityAt == "".  When the
+    instructor then creates and assigns issues, nothing else can detect it: creating an
+    issue moves neither pushedAt nor updatedAt.  If the activityAt comparison is guarded on
+    truthiness rather than on presence, "" is falsy, the comparison is skipped, and the repo
+    is never re-drained -- indefinitely, which is the original #470 bug wearing a new hat.
+
+    21 of 80 live journals had activityAt == "" when this was found.
     """
-    old = journal(updated="", activity="", schema=CURRENT - 1)
+    fresh = journal(activity="")          # published, no issues yet
+    after = remote(activity=LATER)        # instructor creates the first issue
+    check("first issue ever on a freshly published repo -> activity",
+          sync_all.staleness_reason(fresh, after) == "activity")
+
+
+def test_absent_and_empty_are_not_the_same():
+    # None: the journal predates the field, so there is nothing to compare -- fall through
+    # to the schema check. "": the repo really has no issues -- compare it.
+    check("absent activityAt (pre-upgrade journal) -> schema-upgrade",
+          sync_all.staleness_reason(journal(activity=None, schema=CURRENT - 1),
+                                    remote(activity=LATER)) == "schema-upgrade")
+    check("empty activityAt (no issues yet) -> compared, not skipped",
+          sync_all.staleness_reason(journal(activity=""),
+                                    remote(activity=LATER)) == "activity")
+    check("same treatment for updatedAt",
+          sync_all.staleness_reason(journal(updated=None, schema=CURRENT - 1),
+                                    remote(updated=LATER)) == "schema-upgrade")
+
+
+def test_pre_upgrade_journal_upgrades_once_not_forever():
+    """A journal written before these fields existed must not be reported stale forever.
+
+    main() reads a missing field as None, so there is nothing to compare and it falls
+    through to the schema check, which re-drains the repo exactly once and writes it.
+    Represented as None here rather than "" because that distinction is load-bearing --
+    see test_absent_and_empty_are_not_the_same.
+    """
+    old = journal(updated=None, activity=None, schema=CURRENT - 1)
     check("pre-upgrade journal -> schema-upgrade, not activity",
           sync_all.staleness_reason(old, remote(activity=LATER)) == "schema-upgrade")
     check("after the upgrade drain it is quiet again",


### PR DESCRIPTION
A live correctness bug in #475, found by the review on #559. **The classroom flow is still broken on `main` right now.**

## What happens

#475 guarded the `activityAt` comparison on truthiness:

```python
if journal.get("activityAt") and journal["activityAt"] != remote["activityAt"]:
```

A repo published with no issues yet is journaled with `activityAt == ""`. That is falsy, so the comparison is **skipped entirely**. And nothing else catches the case — creating an issue moves neither `pushedAt` nor `updatedAt`, which is the whole finding that motivated #475 in the first place.

Reproduced against the merged code:

```
journal: pushedAt 18:22:43Z  updatedAt 18:28:07Z  activityAt ""      schemaVersion 4
remote:  pushedAt 18:22:43Z  updatedAt 18:28:07Z  activityAt 18:30:05Z
staleness_reason(...) -> None
```

`None` means never re-drained. Not "in an hour" — never. That is #470 again in the exact sequence that broke the class: publish a repo, then create and assign issues on it.

**21 of the 80 live journals have `activityAt == ""`** and are in that state today.

## The fix

Absent and empty now mean different things, because they describe different situations:

| value | meaning | behavior |
|---|---|---|
| `None` | journal predates the field | nothing to compare; falls through to the `schemaVersion` check, which re-drains once and writes it |
| `""` | repo genuinely has no issues or PRs yet | compared, so the first issue is detected |

`main()` reads a missing field as `None` rather than `""`, and `staleness_reason` tests `is not None` rather than truthiness. `updatedAt` had the identical guard and the identical hole, so it gets the same treatment.

## Tests

Two new cases, plus a rewrite of the pre-upgrade test to use `None` rather than `""` — it was passing for the wrong reason, since both values took the same branch before:

- `test_first_issue_on_a_freshly_published_repo` — the failing case above
- `test_absent_and_empty_are_not_the_same` — pins the distinction in both directions and for both fields

All three suites pass.

## Note for whoever picks this up

No backfill is needed. The 21 affected journals already carry `activityAt: ""`, and after this change that value is compared rather than skipped, so the next sweep behaves correctly for them without a schema bump.

Worth reflecting on that this is the second bug in the same three lines in one day, both of the same shape: a value that looks absent being treated as "no information" when it actually carries information. The first was `Repository.updatedAt` appearing to mean something it did not; this one is `""` appearing to mean nothing when it means "no issues yet."

🤖 Generated with [Claude Code](https://claude.com/claude-code)